### PR TITLE
Add harmonic and random palette generation

### DIFF
--- a/src/app/core/app-state.store.ts
+++ b/src/app/core/app-state.store.ts
@@ -16,6 +16,7 @@ import {loadAppStateReducer} from "./common/persistence.reducers";
 import {commonEvents} from "./common/common.events";
 import {colorThemeChangedReducer} from "./common/common.reducers";
 import {
+  newPaletteReducer,
   newRandomPaletteReducer,
   paletteChangedReducer,
   restorePaletteReducer,
@@ -42,6 +43,7 @@ export const AppStateStore = signalStore(
     on(converterEvents.useBezierChanged, useBezierReducer),
     on(converterEvents.displayColorSpaceChanged, displayColorSpaceReducer),
     on(palettesEvents.newRandomPalette, newRandomPaletteReducer),
+    on(palettesEvents.newPalette, newPaletteReducer),
     on(palettesEvents.restorePalette, restorePaletteReducer),
     on(palettesEvents.updatePaletteColor, updatePaletteColorReducer),
     on(palettesEvents.paletteChanged, paletteChangedReducer),

--- a/src/app/core/models/app-state.model.ts
+++ b/src/app/core/models/app-state.model.ts
@@ -41,9 +41,9 @@ export const initialState: AppState = {
   tintColors: createTints(initialColor, true, true),
   shadeColors: createShades(initialColor, true, true),
 
-  paletteStyle: "muted-analog-split",
+  paletteStyle: "random",
   useRandomStyle: false,
-  currentPalette: generatePalette("muted-analog-split"),
+  currentPalette: generatePalette("random"),
 
   colorTheme: "system"
 };

--- a/src/app/core/palettes/palettes.events.ts
+++ b/src/app/core/palettes/palettes.events.ts
@@ -9,6 +9,7 @@ export const palettesEvents = eventGroup({
   source: "Palettes",
   events: {
     newRandomPalette: type<void>(),
+    newPalette: type<void>(),
     restorePalette: type<string>(),
     updatePaletteColor: type<PaletteColor>(),
     paletteChanged: type<Palette>(),

--- a/src/app/core/palettes/palettes.reducers.ts
+++ b/src/app/core/palettes/palettes.reducers.ts
@@ -10,6 +10,19 @@ import {AppState} from "@core/models/app-state.model";
 export function newRandomPaletteReducer(
   this: void,
   event: EventInstance<"[Palettes] newRandomPalette", void>,
+) {
+  const style: PaletteStyle = "random";
+
+  return {
+    currentPalette: generatePalette(style),
+    paletteStyle: style
+  };
+}
+
+
+export function newPaletteReducer(
+  this: void,
+  event: EventInstance<"[Palettes] newPalette", void>,
   state: AppState
 ) {
   const paletteColors = getPinnedPaletteColors(state);

--- a/src/app/header/components/top-bar/top-bar.ts
+++ b/src/app/header/components/top-bar/top-bar.ts
@@ -63,7 +63,7 @@ export class TopBar implements OnInit, OnDestroy {
   protected triggerNew() {
     switch (this.#newClickSource) {
       case "palettes":
-        this.#palettesDispatch.newRandomPalette();
+        this.#palettesDispatch.newPalette();
         return;
       case "convert":
         this.#converterDispatch.newRandomColor();

--- a/src/app/palettes/helper/harmonic-palette.helper.ts
+++ b/src/app/palettes/helper/harmonic-palette.helper.ts
@@ -1,0 +1,95 @@
+import {Palette, PaletteColors} from "@palettes/models/palette.model";
+import {paletteColorFrom} from "@palettes/models/palette-color.model";
+import {fromHsl} from "@common/helpers/color-from-hsl.helper";
+import {randomBetween} from "@common/helpers/random.helper";
+import {clamp01, hueWrap} from "@common/helpers/hsl.helper";
+import {styleCaptionFor} from "@palettes/models/palette-style.model";
+import {colorName} from "@common/helpers/color-name.helper";
+import {paletteIdFromPalette} from "@palettes/helper/palette-id.helper";
+import {vary} from "@palettes/helper/number.helper";
+
+
+/**
+ * Generates a harmonic color palette based on the provided colors and an
+ * optional seed hue.
+ *
+ * @param paletteColors - Optional fixed colors to use when generating the
+ *                        palette. Each provided color is left untouched, and
+ *                        the remaining colors are generated based on the
+ *                        provided seed hue. If no colors are provided, a
+ *                        random neutral color is generated.
+ * @param {number} [seedHue] - Optional seed hue (in degrees) to generate the
+ *                             color palette. If not provided, a random hue
+ *                             is used.
+ * @return {Palette} The generated palette
+ */
+export function generateHarmonic(paletteColors: Partial<PaletteColors> = {},
+                                 seedHue?: number): Palette {
+  const existingNeutral = paletteColors.color0;
+  const [h, s, l] = existingNeutral?.color.hsl() ?? [
+    seedHue ?? randomBetween(0, 360),
+    randomBetween(0, 1),
+    randomBetween(0, 1)
+  ];
+
+  const variation = 0.05;
+
+  const color0 = existingNeutral ?? paletteColorFrom(
+    fromHsl({h, s, l}),
+    "color0"
+  );
+
+  // Analogous
+  const color1 = paletteColors.color1 ?? paletteColorFrom(
+    fromHsl({
+      h: hueWrap(h + 30),
+      s: clamp01(vary(s * 0.9, variation)),
+      l: clamp01(vary(l * 1.1, variation))
+    }),
+    "color1"
+  );
+
+  // Analogous
+  const color2 = paletteColors.color2 ?? paletteColorFrom(
+    fromHsl({
+      h: hueWrap(h + 60),
+      s: clamp01(vary(s * 0.8, variation)),
+      l: clamp01(vary(l * 0.9, variation))
+    }),
+    "color2"
+  );
+
+  // Complementary
+  const color3 = paletteColors.color3 ?? paletteColorFrom(
+    fromHsl({
+      h: hueWrap(h + 180),
+      s: clamp01(vary(s, variation)),
+      l: clamp01(vary(l, variation))
+    }),
+    "color3"
+  );
+
+  // Triadic
+  const color4 = paletteColors.color4 ?? paletteColorFrom(
+    fromHsl({
+      h: hueWrap(h + 150),
+      s: clamp01(vary(s * 0.7, variation)),
+      l: clamp01(vary(l * 1.2, variation))
+    }),
+    "color4"
+  );
+
+  const palette: Palette = {
+    id: "",
+    name: `${styleCaptionFor("harmonic")} – ${colorName(color0.color)}`,
+    style: "harmonic",
+    color0,
+    color1,
+    color2,
+    color3,
+    color4,
+  };
+  palette.id = paletteIdFromPalette(palette);
+
+  return palette;
+}

--- a/src/app/palettes/helper/palette.helper.ts
+++ b/src/app/palettes/helper/palette.helper.ts
@@ -8,16 +8,22 @@ import {generateComplementary} from "@palettes/helper/complementary-palette.help
 import {generateTriadic} from "@palettes/helper/triadic-palette.helper";
 import {generateAnalogous} from "@palettes/helper/analogous-palette.helper";
 import {generateSplitComplementary} from "@palettes/helper/split-complementary-palette.helper";
+import {generateHarmonic} from "@palettes/helper/harmonic-palette.helper";
+import {generateRandom} from "@palettes/helper/random-palette.helper";
 
 
 export function generatePalette(style: PaletteStyle,
                                 paletteColors: Partial<PaletteColors> = {},
                                 seedHue?: number): Palette {
   switch (style) {
+    case "random":
+      return generateRandom(paletteColors, seedHue);
     case "analogous":
       return generateAnalogous(paletteColors, seedHue);
     case 'muted-analog-split':
       return generateMutedAnalogSplit(paletteColors, seedHue);
+    case "harmonic":
+      return generateHarmonic(paletteColors, seedHue);
     case "monochromatic":
       return generateMonochromatic(paletteColors, seedHue);
     case 'vibrant-balanced':
@@ -31,6 +37,6 @@ export function generatePalette(style: PaletteStyle,
     case "split-complementary":
       return generateSplitComplementary(paletteColors, seedHue);
     default:
-      return generateAnalogous(paletteColors, seedHue);
+      return generateRandom(paletteColors, seedHue);
   }
 }

--- a/src/app/palettes/helper/random-palette.helper.ts
+++ b/src/app/palettes/helper/random-palette.helper.ts
@@ -1,0 +1,53 @@
+import {Palette, PALETTE_SLOTS, PaletteColors} from "@palettes/models/palette.model";
+import {paletteColorFrom} from "@palettes/models/palette-color.model";
+import chroma from "chroma-js";
+import {styleCaptionFor} from "@palettes/models/palette-style.model";
+import {colorName} from "@common/helpers/color-name.helper";
+import {paletteIdFromPalette} from "@palettes/helper/palette-id.helper";
+import {randomBetween} from "@common/helpers/random.helper";
+
+
+/**
+ * Generates a random palette of colors based on optional input and a seed.
+ *
+ * @param paletteColors - Optional fixed colors to use when generating the
+ *                        palette. Each provided color is left untouched, and
+ *                        the remaining colors are generated based on the
+ *                        provided seed hue. If no colors are provided, a
+ *                        random neutral color is generated.
+ * @param {number} [seedHue] - Optional seed hue (in degrees) to generate the
+ *                             color palette. If not provided, a random hue
+ *                             is used.
+ * @return {Palette} The generated palette
+ */
+export function generateRandom(paletteColors: Partial<PaletteColors> = {},
+                               seedHue?: number): Palette {
+  const [h, s, l] = paletteColors.color0?.color.hsl() ?? [
+    seedHue ?? randomBetween(0, 360),
+    randomBetween(0, 1),
+    randomBetween(0, 1)
+  ];
+
+  const [color0, color1, color2, color3, color4] = PALETTE_SLOTS
+    .map(slot => {
+      if (slot === "color0") {
+        return paletteColorFrom(chroma.hsl(h, s, l), slot);
+      }
+
+      return paletteColors[slot] ?? paletteColorFrom(chroma.random(), slot);
+    });
+
+  const palette: Palette = {
+    id: "",
+    name: `${styleCaptionFor("random")} – ${colorName(color0.color)}`,
+    style: "random",
+    color0,
+    color1,
+    color2,
+    color3,
+    color4
+  };
+  palette.id = paletteIdFromPalette(palette);
+
+  return palette;
+}

--- a/src/app/palettes/models/palette-style.model.ts
+++ b/src/app/palettes/models/palette-style.model.ts
@@ -2,8 +2,10 @@ import {randomBetween} from "@common/helpers/random.helper";
 
 
 export const PaletteStyles = [
+  "random",
   "analogous",
   "muted-analog-split",
+  "harmonic",
   "monochromatic",
   "vibrant-balanced",
   "high-contrast",
@@ -24,22 +26,26 @@ export function randomStyle(): PaletteStyle {
 
 export function styleCaptionFor(style: PaletteStyle): string {
   switch (style) {
-    case "monochromatic":
-      return "Monochromatic";
-    case "complementary":
-      return "Complementary";
-    case "split-complementary":
-      return "Split Complementary";
-    case "triadic":
-      return "Triadic";
+    case "random":
+      return "Random";
     case "analogous":
       return "Analogous";
+    case "muted-analog-split":
+      return "Muted Analogous";
+    case "harmonic":
+      return "Harmonic";
+    case "monochromatic":
+      return "Monochromatic";
     case "vibrant-balanced":
       return "Vibrant";
     case "high-contrast":
       return "High Contrast";
-    case "muted-analog-split":
-      return "Muted Analogous";
+    case "triadic":
+      return "Triadic";
+    case "complementary":
+      return "Complementary";
+    case "split-complementary":
+      return "Split Complementary";
     default:
       return "";
   }
@@ -48,20 +54,24 @@ export function styleCaptionFor(style: PaletteStyle): string {
 
 export function styleDescriptionFor(style: PaletteStyle): string {
   switch (style) {
-    case "vibrant-balanced":
-      return "A palette with three vibrant accent colors derived from a triad and two light complementary tones.";
-    case "muted-analog-split":
-      return "A muted palette featuring neutral, analogous, pastel and complementary colors with reduced saturation.";
-    case "high-contrast":
-      return "A high-contrast palette with vibrant accents, deep tones, and near-white colors for maximum visual impact.";
-    case "monochromatic":
-      return "A palette based on a single color with different saturation levels and lightness levels.";
-    case "complementary":
-      return "A palette based on two colors positioned opposite each other on the color wheel.";
-    case "triadic":
-      return "A palette using three colors equally spaced around the color wheel.";
+    case "random":
+      return "A random palette generated using a combination of random colors.";
     case "analogous":
       return "A palette using colors that are next to each other on the color wheel.";
+    case "muted-analog-split":
+      return "A muted palette featuring neutral, analogous, pastel and complementary colors with reduced saturation.";
+    case "harmonic":
+      return "A palette based on three colors derived from a triad and two complementary tones.";
+    case "monochromatic":
+      return "A palette based on a single color with different saturation levels and lightness levels.";
+    case "vibrant-balanced":
+      return "A palette with three vibrant accent colors derived from a triad and two light complementary tones.";
+    case "high-contrast":
+      return "A high-contrast palette with vibrant accents, deep tones, and near-white colors for maximum visual impact.";
+    case "triadic":
+      return "A palette using three colors equally spaced around the color wheel.";
+    case "complementary":
+      return "A palette based on two colors positioned opposite each other on the color wheel.";
     case "split-complementary":
       return "A palette using a base color and two colors adjacent to its complement.";
     default:


### PR DESCRIPTION
### Summary

This pull request introduces two new palette generation styles: `harmonic` and `random`. Updates include:

- Added `harmonic` palette style for triadic and complementary color combinations.
- Introduced `random` palette style for generating palettes with random colors.
- Updated palette helper functions, reducers, and models to support these styles.
- Integrated `generateHarmonic` and `generateRandom` palette generator functions.
- Adjusted defaults and descriptions for smoother integration. 
