### PR TITLE
Update `webFontsApiUrl` path in environment config

### DIFF
--- a/src/environments/environment.gh-pages.ts
+++ b/src/environments/environment.gh-pages.ts
@@ -3,5 +3,5 @@ import {Environment} from "./environment.model";
 
 export const environment: Environment = {
   quotesApiUrl: "https://quote-proxy.ray-7b9.workers.dev/api",
-  webFontsApiUrl: "https://google-webfonts-proxy.ray-7b9.workers.dev"
+  webFontsApiUrl: "https://google-webfonts-proxy.ray-7b9.workers.dev/webfonts"
 };


### PR DESCRIPTION
## Description
- Updated the `webFontsApiUrl` configuration in the gh-pages environment to include the `/webfonts` path.
- Ensures the API endpoint is accurate for the correct functionality of the web fonts feature.