### PR TITLE
Clean up after the Angular 22 upgrade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,9 +294,29 @@ Components use inline SCSS styles configured in `angular.json`:
 - Global entry point is `src/styles.scss`
 - Cross-cutting styles live in `src/app/styles/` as topic-separated partials
   (`_variables.scss`, `_dark-mode.scss`, `_bootstrap-custom.scss`,
-  `converter.scss`, `contrast.scss`, `color-palette.scss`, `sliders.scss`,
-  `drag-n-drop.scss`)
+  `_bootstrap-subset.scss`, `converter.scss`, `contrast.scss`,
+  `color-palette.scss`, `sliders.scss`, `drag-n-drop.scss`)
 - Uses Bootstrap 5.3 and Bootstrap Icons
+
+### Bootstrap Is Imported As A Subset
+
+`src/app/styles/_bootstrap-subset.scss` replaces `bootstrap/scss/bootstrap`. It
+mirrors Bootstrap's own import stack but leaves out the fourteen components
+nothing in `src` renders, which saves ~51 kB of raw CSS.
+
+**Adding a Bootstrap component means adding its partial to that file.** A
+missing partial does not fail the build - the component renders unstyled, which
+only shows up visually. The same applies to anything ng-bootstrap draws at
+runtime: `NgbDropdown`, `NgbTooltip` and `NgbTypeahead` need `dropdown`,
+`tooltip` and `transitions`, none of which appear in any template.
+
+The file uses `@import` rather than `@use`, because Bootstrap 5.3's partials
+read variables and mixins from the global scope and are not `@use`-able in
+isolation. That is why `angular.json` sets
+`stylePreprocessorOptions.sass.silenceDeprecations: ["import"]` - without it the
+build emits 21 deprecation warnings for our own file, while Bootstrap's
+identical `@import`s stay quiet as a dependency. Configuration still flows
+through `@use "./bootstrap-subset" with (...)` in `_bootstrap-custom.scss`.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,31 @@ This allows contrast color pairs to be shared via URL: `/contrast/{contrastId}`
 The app uses two main color libraries:
 
 - **chroma-js** - Primary color manipulation (conversions, interpolation, color math)
-- **color-namer** - Color name identification
+- **color-namer** - Color name identification, used for its color lists only
+
+`src/app/common/helpers/color-name.helper.ts` deliberately does **not** call
+`color-namer`'s own entry point. It imports the six color lists
+(`color-namer/lib/colors/*`) and does the nearest-color search with the app's
+own chroma-js. Importing the package proper pulls in a second, much older
+chroma-js (1.4.1) plus `es6-weak-map` and its `es5-ext` tail - 59 kB of raw
+bundle for a `WeakMap` cache that never hits, because `color-namer` keys it on a
+freshly allocated object on every call.
+
+Both variants produce identical names. The deep imports are declared in
+`src/types/color-namer-lists.d.ts` and listed in `allowedCommonJsDependencies`
+in `angular.json`, because the lists are CommonJS.
+
+**The distance must be measured from `color.hex()`, not from the `Color`
+object.** `color-namer` was always handed a hex string, so it compared the
+rounded 8-bit color; a chroma `Color` carries unrounded channels, and
+`chroma.hsl()` plus the Bezier interpolation used for tints, shades and palettes
+produce fractional ones. Passing the object through renames roughly 5 % of those
+colors and makes a palette disagree with its own shared-URL round trip, which
+goes through 8-bit RGB. A sweep over the integer RGB cube cannot detect this -
+there the two agree exactly. `color-name.helper.spec.ts` pins the behaviour.
+
+Note that `colorName()` must stay synchronous: `generatePalette()` and
+`paletteFromId()` call it from reducer and route-guard code paths.
 
 ### Path Aliases
 
@@ -326,5 +350,6 @@ through `@use "./bootstrap-subset" with (...)` in `_bootstrap-custom.scss`.
   explicit environment setting and no `vitest.config.*` in the repo
 - Run all tests: `ng test` (or `pnpm test`); `ng test --watch=false` for a single run
 - Component generation skips test files by default (configured in angular.json schematics)
-- The suite currently consists of 138 tests in 4 helper specs (palette ID,
-  contrast ID, APCA rating, optimal text color). No component or store is tested
+- The suite currently consists of 149 tests in 5 helper specs (palette ID,
+  contrast ID, APCA rating, optimal text color, color name). No component or
+  store is tested

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,12 @@ there the two agree exactly. `color-name.helper.spec.ts` pins the behaviour.
 Note that `colorName()` must stay synchronous: `generatePalette()` and
 `paletteFromId()` call it from reducer and route-guard code paths.
 
+### Bundle Budget
+
+The initial budget is 1 MB warning / 1.2 MB error against a current 936 kB. It
+is meant to catch regressions, so keep it close to the actual size rather than
+raising it to make a warning go away.
+
 ### Path Aliases
 
 TypeScript path aliases are configured in `tsconfig.json`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,10 @@ codebase actually does.
   `ChangeDetectionStrategy.Eager` opts out of it and needs a written reason
 - Use signals for state management via `signal()`, `computed()`, and `effect()`
 - Use `input()` and `output()` functions instead of decorators
+- `model()` already provides an `xChange` output. Do NOT add a second manual
+  `output()` next to it - consumers bind `(xChange)`, and a component that
+  writes to its own model signal emits it automatically (see the sliders in
+  `src/app/common/components/`)
 - Prefer signal queries (`viewChild()`, `contentChild()`) over the decorators
 - Prefer inline templates for tiny components
 - Use native control flow (`@if`, `@for`, `@switch`) instead of structural directives

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,7 +250,11 @@ Only template-driven forms are in use:
 
 ### Services
 
-- Use `providedIn: 'root'` for singleton services
+- Use the Angular 22 `@Service()` decorator for singleton services. It is
+  auto-provided in the root injector, so `@Injectable({providedIn: 'root'})` is
+  no longer needed - there is no `@Injectable` left in `src`
+- Use `@Injectable()` only where a class genuinely must not be root-provided
+  (or `@Service({autoProvided: false})` and an explicit `providers` entry)
 - Use the `inject()` function instead of constructor injection
 - Design services around a single responsibility
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,12 +228,13 @@ codebase actually does.
 
 ### Forms
 
-Both form styles are in use, and that is deliberate:
+Only template-driven forms are in use:
 
-- `FormsModule` with `ngModel` for the small numeric and text value inputs
-  (RGB, HSL, hex, sliders) - this is the dominant pattern
-- `ReactiveFormsModule` where a control needs validation or programmatic
-  wiring (e.g. the font selector typeahead)
+- `FormsModule` with `ngModel` for every value input - the numeric and text
+  fields (RGB, HSL, hex), the sliders and the font selector typeahead
+- `ReactiveFormsModule` is deliberately absent. There is no `FormControl`,
+  `FormGroup` or `formControl` binding anywhere in `src`. Do not add the import
+  "just in case" - add it only together with an actual reactive control
 - Do NOT wrap inputs in a `<form>` element for layout only. An implicit
   `NgForm` breaks `ngModel` registration across component boundaries and
   Angular 22 reports it as NG01354 (see commit `d03d83f`)

--- a/angular.json
+++ b/angular.json
@@ -32,6 +32,13 @@
             "styles": [
               "src/styles.scss"
             ],
+            "stylePreprocessorOptions": {
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
+            },
             "polyfills": [
               "@angular/localize/init"
             ]

--- a/angular.json
+++ b/angular.json
@@ -39,6 +39,14 @@
                 ]
               }
             },
+            "allowedCommonJsDependencies": [
+              "color-namer/lib/colors/basic",
+              "color-namer/lib/colors/html",
+              "color-namer/lib/colors/ntc",
+              "color-namer/lib/colors/pantone",
+              "color-namer/lib/colors/roygbiv",
+              "color-namer/lib/colors/x11"
+            ],
             "polyfills": [
               "@angular/localize/init"
             ]

--- a/angular.json
+++ b/angular.json
@@ -56,8 +56,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
-                  "maximumError": "1.5MB"
+                  "maximumWarning": "1MB",
+                  "maximumError": "1.2MB"
                 },
                 {
                   "type": "anyComponentStyle",
@@ -71,8 +71,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
-                  "maximumError": "1.5MB"
+                  "maximumWarning": "1MB",
+                  "maximumError": "1.2MB"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/src/app/common/components/color-picker/color-picker.html
+++ b/src/app/common/components/color-picker/color-picker.html
@@ -19,7 +19,7 @@
                      (valueChange)="onValueChanged($event)"/>
 
       <ct-hue-slider [(hue)]="hue"
-                     (hueChanged)="onHueChanged($event)"/>
+                     (hueChange)="onHueChanged($event)"/>
 
       <div class="color-picker-input-row">
         <input type="text"

--- a/src/app/common/components/hsl-color-edit/hsl-color-edit.html
+++ b/src/app/common/components/hsl-color-edit/hsl-color-edit.html
@@ -2,18 +2,18 @@
   H
   <ct-hue-slider class="w-100"
                   [hue]="colorHue()"
-                  (hueChanged)="updateHue($event)"/>
+                  (hueChange)="updateHue($event)"/>
 </div>
 <div class="hstack">
   S
   <ct-saturation-slider class="w-100"
                          [sat]="colorSaturation()"
-                         (satChanged)="updateSaturation($event)"
+                         (satChange)="updateSaturation($event)"
                          [baseColor]="color()"/>
 </div>
 <div class="hstack">
   L
   <ct-luminance-slider class="w-100"
                         [lum]="colorLuminance()"
-                        (lumChanged)="updateLuminance($event)"/>
+                        (lumChange)="updateLuminance($event)"/>
 </div>

--- a/src/app/common/components/hue-slider/hue-slider.html
+++ b/src/app/common/components/hue-slider/hue-slider.html
@@ -3,6 +3,5 @@
          type="range"
          min="0"
          max="360"
-         [(ngModel)]="hue"
-         (ngModelChange)="onHueChanged($event)"/>
+         [(ngModel)]="hue"/>
 </div>

--- a/src/app/common/components/hue-slider/hue-slider.ts
+++ b/src/app/common/components/hue-slider/hue-slider.ts
@@ -1,4 +1,4 @@
-import {Component, model, output} from "@angular/core";
+import {Component, model} from "@angular/core";
 import {FormsModule} from "@angular/forms";
 
 import {randomBetween} from "@common/helpers/random.helper";
@@ -13,11 +13,5 @@ import {randomBetween} from "@common/helpers/random.helper";
 export class HueSliderComponent {
 
   public readonly hue = model<number>(randomBetween(0, 360));
-  public readonly hueChanged = output<number>();
-
-
-  protected onHueChanged(value: number) {
-    this.hueChanged.emit(value);
-  }
 
 }

--- a/src/app/common/components/luminance-slider/luminance-slider.html
+++ b/src/app/common/components/luminance-slider/luminance-slider.html
@@ -3,6 +3,5 @@
          type="range"
          min="0"
          max="100"
-         [(ngModel)]="lum"
-         (ngModelChange)="onLumChanged($event)"/>
+         [(ngModel)]="lum"/>
 </div>

--- a/src/app/common/components/luminance-slider/luminance-slider.ts
+++ b/src/app/common/components/luminance-slider/luminance-slider.ts
@@ -1,4 +1,4 @@
-import {Component, model, output} from "@angular/core";
+import {Component, model} from "@angular/core";
 import {FormsModule} from "@angular/forms";
 import {randomBetween} from "@common/helpers/random.helper";
 
@@ -14,11 +14,5 @@ import {randomBetween} from "@common/helpers/random.helper";
 export class LuminanceSlider {
 
   public readonly lum = model<number>(randomBetween(0, 100));
-  public readonly lumChanged = output<number>();
-
-
-  protected onLumChanged(value: number) {
-    this.lumChanged.emit(value);
-  }
 
 }

--- a/src/app/common/components/saturation-slider/saturation-slider.html
+++ b/src/app/common/components/saturation-slider/saturation-slider.html
@@ -5,6 +5,5 @@
          max="100"
          [style.--ct-sat-slider-color-hue]="hue()"
          [style.--ct-sat-slider-color-l]="luminance()"
-         [(ngModel)]="sat"
-         (ngModelChange)="onSatChanged($event)"/>
+         [(ngModel)]="sat"/>
 </div>

--- a/src/app/common/components/saturation-slider/saturation-slider.ts
+++ b/src/app/common/components/saturation-slider/saturation-slider.ts
@@ -1,4 +1,4 @@
-import {Component, computed, input, model, output} from "@angular/core";
+import {Component, computed, input, model} from "@angular/core";
 import {FormsModule} from "@angular/forms";
 import {randomBetween} from "@common/helpers/random.helper";
 import chroma from "chroma-js";
@@ -26,11 +26,5 @@ export class SaturationSlider {
 
   public readonly baseColor = input(chroma.random());
   public readonly sat = model<number>(randomBetween(0, 100));
-  public readonly satChanged = output<number>();
-
-
-  protected onSatChanged(value: number) {
-    this.satChanged.emit(value);
-  }
 
 }

--- a/src/app/common/helpers/color-name.helper.spec.ts
+++ b/src/app/common/helpers/color-name.helper.spec.ts
@@ -1,0 +1,101 @@
+import chroma from "chroma-js";
+import {colorName} from "@common/helpers/color-name.helper";
+
+
+describe("Color Name Helper", () => {
+
+  describe("colorName", () => {
+
+    describe("exact matches from the color lists", () => {
+
+      it("should name pure red", () => {
+        expect(colorName(chroma("#ff0000"))).toBe("red");
+      });
+
+      it("should name pure white", () => {
+        expect(colorName(chroma("#ffffff"))).toBe("white");
+      });
+
+      it("should name pure black", () => {
+        expect(colorName(chroma("#000000"))).toBe("black");
+      });
+
+      it("should name an exact x11 color", () => {
+        expect(colorName(chroma("#4682b4"))).toBe("steelblue");
+      });
+
+    });
+
+
+    describe("Pantone preference", () => {
+
+      it("should prefer a Pantone name that is within the tolerance", () => {
+        // Closest overall is "True V" at 2.75; the closest Pantone entry
+        // "Blue Violet" is at 7.40, still within 2.75 + 5.
+        expect(colorName(chroma("#8474d4"))).toBe("Blue Violet");
+      });
+
+      it("should keep the closest name when Pantone is beyond the tolerance", () => {
+        // Closest overall "Prussian Blue" at 2.40, closest Pantone
+        // "Midnight Blue" at 11.05 - far outside 2.40 + 5.
+        expect(colorName(chroma("#123456"))).toBe("Prussian Blue");
+      });
+
+    });
+
+
+    describe("channel quantization", () => {
+
+      // `chroma.hsl()` and the Bezier interpolation used for tints, shades and
+      // palettes produce colors with fractional RGB channels. The name must be
+      // derived from the 8-bit color the user actually sees, not from the
+      // unrounded channels - otherwise a color and its shared-palette-ID
+      // round-trip (which goes through 8-bit RGB) get different names.
+      it("should name a fractional color like its rounded hex", () => {
+        const fractional = chroma.hsl(0, 0.2, 0.9);
+
+        expect(fractional.hex()).toBe("#ebe0e0");
+        expect(colorName(fractional)).toBe(colorName(chroma("#ebe0e0")));
+        expect(colorName(fractional)).toBe("Timberwolf");
+      });
+
+      it("should name a fractional dark color like its rounded hex", () => {
+        const fractional = chroma.hsl(5, 0.4, 0.2);
+
+        expect(fractional.hex()).toBe("#47221f");
+        expect(colorName(fractional)).toBe(colorName(chroma("#47221f")));
+        expect(colorName(fractional)).toBe("Crater Brown");
+      });
+
+      it("should name a fractional mid-tone like its rounded hex", () => {
+        const fractional = chroma.hsl(10, 0.3, 0.3);
+
+        expect(fractional.hex()).toBe("#633d36");
+        expect(colorName(fractional)).toBe(colorName(chroma("#633d36")));
+        expect(colorName(fractional)).toBe("Congo Brown");
+      });
+
+    });
+
+
+    describe("stability across the palette-ID round trip", () => {
+
+      // A shared palette URL stores 8-bit RGB. A color and its restored twin
+      // must therefore always carry the same name.
+      it("should survive an 8-bit RGB round trip", () => {
+        const original = chroma.hsl(210, 0.55, 0.45);
+        const [r, g, b] = original.rgb();
+        const restored = chroma.rgb(r, g, b);
+
+        expect(colorName(original)).toBe(colorName(restored));
+      });
+
+      it("should never return the Unknown fallback for a valid color", () => {
+        expect(colorName(chroma.hsl(137, 0.42, 0.63))).not.toBe("Unknown");
+      });
+
+    });
+
+  });
+
+});

--- a/src/app/common/helpers/color-name.helper.ts
+++ b/src/app/common/helpers/color-name.helper.ts
@@ -1,25 +1,65 @@
-import ColorNamer from "color-namer";
-import {Color} from "chroma-js";
+import chroma, {Color} from "chroma-js";
+import basic from "color-namer/lib/colors/basic";
+import html from "color-namer/lib/colors/html";
+import ntc from "color-namer/lib/colors/ntc";
+import pantone from "color-namer/lib/colors/pantone";
+import roygbiv from "color-namer/lib/colors/roygbiv";
+import x11 from "color-namer/lib/colors/x11";
+
+/**
+ * How much further away a Pantone match may be and still win over the closest
+ * match from any list. Pantone names read better than the generated ones.
+ */
+const PANTONE_TOLERANCE = 5;
+
+interface NamedColor {
+  name: string;
+  hex: string;
+}
+
+/**
+ * The lists come from `color-namer`, but the distance math does not - see the
+ * Color Libraries section in CLAUDE.md for why the package's own entry point is
+ * bypassed. Order matters: on equal distance the first list wins, which is what
+ * `color-namer` did with its stable sort.
+ */
+const LISTS: readonly NamedColor[][] = [basic, html, ntc, pantone, roygbiv, x11];
 
 
 export function colorName(color: Color): string {
-  const names = ColorNamer(color.hex());
-  const allColors = Object.values(names)
-    .flat()
-    .sort((a, b) => a.distance - b.distance);
+  // Quantize to 8-bit RGB first. `color-namer` was fed `color.hex()`, so the
+  // distances were measured from the rounded color; a chroma `Color` carries
+  // unrounded channels and would name ~5 % of the colors differently.
+  const hex = color.hex();
 
-  if (!allColors.length) return "Unknown";
+  let closest: NamedColor | undefined;
+  let closestDistance = Infinity;
+  let closestPantone: NamedColor | undefined;
+  let closestPantoneDistance = Infinity;
 
-  const bestOverall = allColors[0];
+  for (const list of LISTS) {
+    const isPantone = list === pantone;
 
-  const pantoneList = names.pantone;
-  const bestPantone = pantoneList.length ?
-    pantoneList.sort((a, b) => a.distance - b.distance)[0]
-    : undefined;
+    for (const candidate of list) {
+      const distance = chroma.distance(hex, candidate.hex);
 
-  if (bestPantone && bestPantone.distance <= bestOverall.distance + 5) {
-    return bestPantone.name;
+      if (distance < closestDistance) {
+        closest = candidate;
+        closestDistance = distance;
+      }
+
+      if (isPantone && distance < closestPantoneDistance) {
+        closestPantone = candidate;
+        closestPantoneDistance = distance;
+      }
+    }
   }
 
-  return bestOverall.name;
+  if (!closest) return "Unknown";
+
+  if (closestPantone && closestPantoneDistance <= closestDistance + PANTONE_TOLERANCE) {
+    return closestPantone.name;
+  }
+
+  return closest.name;
 }

--- a/src/app/common/services/color-theme.service.ts
+++ b/src/app/common/services/color-theme.service.ts
@@ -1,11 +1,9 @@
-import {DOCUMENT, inject, Injectable} from '@angular/core';
+import {DOCUMENT, inject, Service} from '@angular/core';
 import {ColorTheme} from '@common/models/color-theme.model';
 import {Color} from "chroma-js";
 
 
-@Injectable({
-  providedIn: 'root'
-})
+@Service()
 export class ColorThemeService {
 
   readonly #document = inject(DOCUMENT);

--- a/src/app/common/services/google-font-loader.service.ts
+++ b/src/app/common/services/google-font-loader.service.ts
@@ -1,5 +1,5 @@
 import {DOCUMENT} from "@angular/common";
-import {inject, Injectable} from "@angular/core";
+import {inject, Service} from "@angular/core";
 import {SelectedFont} from "@common/models/google-font.model";
 
 
@@ -7,9 +7,7 @@ import {SelectedFont} from "@common/models/google-font.model";
  * Service for dynamically loading Google Fonts and managing font-family CSS
  * custom properties. Similar pattern to ColorThemeService for consistency.
  */
-@Injectable({
-  providedIn: "root"
-})
+@Service()
 export class GoogleFontLoaderService {
 
   readonly #document = inject(DOCUMENT);

--- a/src/app/common/services/google-fonts.service.ts
+++ b/src/app/common/services/google-fonts.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from "@angular/core";
+import {Service} from "@angular/core";
 import {GoogleFont, GoogleFontsApiResponse} from "@common/models/google-font.model";
 import {httpResource, HttpResourceRef} from "@angular/common/http";
 import {environment} from "@environments/environment";
@@ -8,9 +8,7 @@ import {environment} from "@environments/environment";
  * Service for interacting with the Google Fonts API.
  * Provides methods for fetching and searching Google Fonts data.
  */
-@Injectable({
-  providedIn: "root"
-})
+@Service()
 export class GoogleFontsService {
 
   /**

--- a/src/app/common/services/local-storage.service.ts
+++ b/src/app/common/services/local-storage.service.ts
@@ -1,11 +1,9 @@
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 import {EMPTY_SETTINGS, LOCAL_STORAGE_KEY, SettingKey, SettingsMap} from '@common/models/local-storage.model';
 import {BehaviorSubject} from "rxjs";
 
 
-@Injectable({
-  providedIn: 'root'
-})
+@Service()
 export class LocalStorage {
 
   private readonly settings = new Map<SettingKey, BehaviorSubject<SettingsMap[SettingKey]>>();

--- a/src/app/contrast/services/quotes.ts
+++ b/src/app/contrast/services/quotes.ts
@@ -1,4 +1,4 @@
-import {computed, Injectable} from '@angular/core';
+import {computed, Service} from '@angular/core';
 import {httpResource} from "@angular/common/http";
 import {environment} from "@environments/environment";
 
@@ -9,9 +9,7 @@ interface ZenQuote {
   h: string
 }
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class Quotes {
 
   readonly #quoteOfTheDay = httpResource<ZenQuote>(() => {

--- a/src/app/converter/components/hex-input/hex-input.html
+++ b/src/app/converter/components/hex-input/hex-input.html
@@ -1,7 +1,7 @@
 <h2>HEX</h2>
 
 <div class="input">
-  <form class="input-form">
+  <div class="input-form">
     <div class="input-a">
       <label for="hexColorField" class="form-label">Hex Color</label>
       <div class="input-group">
@@ -17,7 +17,7 @@
                (blur)="colorChanged()">
       </div>
     </div>
-  </form>
+  </div>
 
   <div app-copy-css colorMode="hex"></div>
 </div>

--- a/src/app/converter/components/hsl-input/hsl-input.ts
+++ b/src/app/converter/components/hsl-input/hsl-input.ts
@@ -1,6 +1,6 @@
 import {Component, computed, inject, linkedSignal} from "@angular/core";
 import chroma from "chroma-js";
-import {FormsModule, ReactiveFormsModule} from "@angular/forms";
+import {FormsModule} from "@angular/forms";
 import {inHslAngleRange, inHslPercentRange} from "@common/helpers/hsl.helper";
 import {RangedInput} from "@converter/components/ranged-input/ranged-input";
 import {CopyCss} from "@converter/components/copy-css/copy-css";
@@ -12,7 +12,6 @@ import {converterEvents} from "@core/converter/converter.events";
 @Component({
   selector: 'ct-hsl-input',
   imports: [
-    ReactiveFormsModule,
     FormsModule,
     CopyCss,
     RangedInput

--- a/src/app/converter/components/ranged-input/ranged-input.ts
+++ b/src/app/converter/components/ranged-input/ranged-input.ts
@@ -1,11 +1,10 @@
 import {Component, computed, input, model, viewChild} from "@angular/core";
-import {FormsModule, NgModel, ReactiveFormsModule} from "@angular/forms";
+import {FormsModule, NgModel} from "@angular/forms";
 
 
 @Component({
   selector: 'div[app-ranged-input]',
   imports: [
-    ReactiveFormsModule,
     FormsModule
   ],
   templateUrl: './ranged-input.html',

--- a/src/app/converter/components/rgb-input/rgb-input.ts
+++ b/src/app/converter/components/rgb-input/rgb-input.ts
@@ -1,5 +1,5 @@
 import {Component, computed, inject, linkedSignal} from "@angular/core";
-import {FormsModule, ReactiveFormsModule} from "@angular/forms";
+import {FormsModule} from "@angular/forms";
 import chroma from "chroma-js";
 import {inRgbRange} from "@common/helpers/rgb.helper";
 import {CopyCss} from "@converter/components/copy-css/copy-css";
@@ -12,7 +12,6 @@ import {AppStateStore} from "@core/app-state.store";
 @Component({
   selector: 'ct-rgb-input',
   imports: [
-    ReactiveFormsModule,
     FormsModule,
     CopyCss,
     RangedInput

--- a/src/app/styles/_bootstrap-custom.scss
+++ b/src/app/styles/_bootstrap-custom.scss
@@ -1,6 +1,7 @@
+
 @use "./variables" as vars;
 
-@use "bootstrap/scss/bootstrap" with (
+@use "./bootstrap-subset" with (
   // Fonts
   $font-family-sans-serif: vars.$fonts,
   $font-family-monospace: vars.$monospacedFonts,

--- a/src/app/styles/_bootstrap-subset.scss
+++ b/src/app/styles/_bootstrap-subset.scss
@@ -1,0 +1,58 @@
+// Bootstrap, imported partial by partial instead of via the full
+// `bootstrap/scss/bootstrap` bundle.
+//
+// This file mirrors the import stack of `node_modules/bootstrap/scss/bootstrap.scss`
+// and drops the components this app never renders. It uses `@import` for the
+// same reason Bootstrap 5.3 itself does: the partials are not `@use`-able in
+// isolation - each one reads variables and mixins from the global scope that
+// the configuration block above it established.
+//
+// It stays configurable through `@use "bootstrap-subset" with (...)`, because
+// the `!default` variables reached via `@import "variables"` become
+// configurable members of this module - exactly as they do for Bootstrap's own
+// entry point.
+//
+// **Adding a Bootstrap component means adding its partial here.** A missing
+// partial does not fail the build; the component simply renders unstyled.
+
+// Configuration - all six are mandatory.
+@import "bootstrap/scss/functions";
+@import "bootstrap/scss/variables";
+@import "bootstrap/scss/variables-dark";
+@import "bootstrap/scss/maps";
+@import "bootstrap/scss/mixins";
+@import "bootstrap/scss/utilities";
+
+// Base - CSS custom properties and the element resets everything else builds on.
+@import "bootstrap/scss/root";
+@import "bootstrap/scss/reboot";
+@import "bootstrap/scss/type"; // headings, .small, blockquote
+
+// Layout
+@import "bootstrap/scss/containers"; // .container-fluid
+@import "bootstrap/scss/grid"; // .row, .col, .col-6, .gx-5
+
+// Components in use
+@import "bootstrap/scss/forms"; // .form-control, .form-check, .form-range, .input-group, .invalid-feedback
+@import "bootstrap/scss/buttons"; // .btn and variants
+@import "bootstrap/scss/transitions"; // .fade - NgbTooltip and NgbTypeahead animate with it
+@import "bootstrap/scss/dropdown"; // NgbDropdown and the NgbTypeahead result list
+@import "bootstrap/scss/button-group"; // .btn-group, .btn-group-vertical
+@import "bootstrap/scss/nav"; // .nav-item, .nav-link
+@import "bootstrap/scss/navbar"; // .navbar-brand, .navbar-nav
+@import "bootstrap/scss/card"; // .card, .card-header, .card-body
+@import "bootstrap/scss/badge"; // .badge
+@import "bootstrap/scss/list-group"; // .list-group and the contextual variants
+@import "bootstrap/scss/tooltip"; // NgbTooltip
+@import "bootstrap/scss/spinners"; // .spinner-border
+
+// Deliberately not imported, because nothing in `src` uses them: accordion,
+// alert, breadcrumb, carousel, close, images, modal, offcanvas, pagination,
+// placeholders, popover, progress, tables, toasts.
+
+// Helpers - .visually-hidden, .hstack, .text-bg-*
+@import "bootstrap/scss/helpers";
+
+// Utilities API - generates .d-flex, .gap-*, .m*/.p*, .fs-*, .fw-*, .text-*,
+// .w-100, .align-items-*, .justify-content-* and the rest. Mandatory.
+@import "bootstrap/scss/utilities/api";

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,8 +1,6 @@
 /* You can add global styles to this file, and also import other style files */
 
 @use "app/styles/bootstrap-custom";
-/* Importing Bootstrap SCSS file. */
-@use "bootstrap/scss/bootstrap";
 
 @use "bootstrap-icons/font/bootstrap-icons.css";
 @use "app/styles/dark-mode";

--- a/src/types/color-namer-lists.d.ts
+++ b/src/types/color-namer-lists.d.ts
@@ -1,0 +1,4 @@
+declare module "color-namer/lib/colors/*" {
+  const list: {name: string; hex: string}[];
+  export default list;
+}


### PR DESCRIPTION
Closes #44.

Seven independent cleanups from the Angular-22 upgrade review, one per commit so
each can be read and reverted on its own.

| Commit | Issue item |
|---|---|
| Remove the unused ReactiveFormsModule imports | 1 |
| Replace `@Injectable({providedIn: "root"})` with `@Service()` | 2 |
| Replace the layout-only form in hex-input with a div | 3 |
| Drop the sliders' manual change outputs | 4 |
| Import Bootstrap as a subset of its partials | 6 |
| Bypass color-namer's entry point and name colors directly | 6 |
| Raise the initial bundle budget to match reality | 6 |

Issue item 5 (Angular 21 → 22, Karma → Vitest in `CLAUDE.md`) was already done
before this branch. The documentation work here fixes *different* drift instead:
the Forms section claimed `ReactiveFormsModule` was used for the font selector
typeahead, the Services section still prescribed `providedIn: 'root'`, and the
`model()`/`output()` rule, the Bootstrap subset, the color-namer decision and the
bundle budget were undocumented. Each doc change rides along with the commit that
makes it true.

## Bundle

| | before | after |
|---|---|---|
| main | 710.78 kB | 644.36 kB |
| styles | 342.03 kB | 291.14 kB |
| **initial total** | **1.05 MB** | **935.99 kB** |
| transferred | 221.26 kB | 199.62 kB |

Both `pnpm build` and `pnpm run build:cloudflare` are now completely
warning-free — the CommonJS bailout warning from issue item 6 is gone as well.

## One behavioural fix worth flagging

The color-namer rewrite nearly changed what the app displays. Distance has to be
measured from `color.hex()`: the package was always handed a hex string and so
compared the rounded 8-bit color, while a chroma `Color` carries unrounded
channels. Passing the object straight through renames ~5 % of fractional colors,
which the app produces everywhere via `chroma.hsl()` and the Bezier
interpolation. Because palette IDs encode 8-bit RGB, a palette and its own shared
`/palettes/{id}` link would have shown different names for the same swatch.

An integer-RGB sweep cannot detect this — `hex()` is lossless there, so both
paths agree by construction. A differential run against the pre-change helper
settled it: integer RGB agreed 0/4000 either way (which also shows the
chroma 1.4.1 → 3.x swap flips no nearest-match at all), while `chroma.hsl()`
floats disagreed 197/4000 before the quantization was restored and 0/4000 after.

## Verification

- **149/149 tests pass** (was 138). The colour-name algorithm is now app code and
  carries its own spec — the old suite asserted nothing about names, so it was no
  evidence at all. Reintroducing the quantization bug fails 3 of the new tests.
- **Bootstrap subset:** compiled the full bundle and the subset separately and
  diffed the selector sets. 132 classes dropped, none among the 160 the templates
  use. No dropped partial defines a `--bs-*` property that `src` reads; no
  `@extend` anywhere. `dropdown`, `tooltip` and `transitions` are kept
  deliberately for the classes ng-bootstrap draws at runtime, which appear in no
  template.
- No lint tooling is configured in this project; TypeScript strict checking runs
  as part of both builds and is clean.

## Known trade-offs

- `silenceDeprecations: ["import"]` sits on the shared `build.options`. Sass takes
  deprecation ids, not paths, so there is no narrower form — and the `test` target
  inherits it via `buildTarget: :build:testing`, which it needs. Cost: a stray
  `@import` in app SCSS will no longer warn.
- `declare module "color-namer/lib/colors/*"` also type-checks paths that do not
  exist. Six explicit declarations would be stricter; the directory holds exactly
  six files and all six are imported.
- `color-picker.html` binds both `[(hue)]` and `(hueChange)`, so `onHueChanged()`
  repeats a `set()` the two-way binding already did. Left alone: `ct-color-area`
  three lines above does the same, so this is a repo-wide pattern and belongs in
  its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)