### PR TITLE
Answer unknown paths with a not-found page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,11 @@ testem.log
 __screenshots__/
 /public/palette2.svg
 /.claude/settings.local.json
+
+# Claude Design canvas exports - only the .dc.html draft is worth keeping.
+# The archive, the canvas runtime and the reference screenshots are
+# regenerated on every export and cost megabytes.
+resources/*.zip
+resources/**/uploads/
+resources/**/support.js
+resources/**/.thumbnail

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,24 @@ remote while its working tree looks current, because files copied in by hand
 are untracked. `git -C .claude fetch` and compare with
 `git -C .claude rev-list --left-right --count origin/main...HEAD` first.
 
+## Writing Text For GitHub
+
+Anything GitHub renders as HTML is **not** hard-wrapped - its UI does the
+wrapping, and a hard wrap produces ragged paragraphs and breaks quoting in
+comments. This covers issue bodies and comments, PR descriptions, PR and review
+comments, replies to review comments, and release notes.
+
+One paragraph is one line. Break only where the break carries meaning: between
+paragraphs, per list item, per table row, and around code blocks.
+
+Hard-wrapping stays for anything read in monospace without reflow: commit
+messages (subject at most 50 characters, body wrapped at 72), files in this
+repository including this one, and code comments.
+
+This is the convention from the `.claude` submodule's README, adopted here
+because that README asks each project to adopt it explicitly - the rule applies
+whenever GitHub text is written, including when no skill is running.
+
 ## Architecture
 
 ### State Management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,9 +206,9 @@ Note that `colorName()` must stay synchronous: `generatePalette()` and
 
 ### Bundle Budget
 
-The initial budget is 1 MB warning / 1.2 MB error against a current 936 kB. It
-is meant to catch regressions, so keep it close to the actual size rather than
-raising it to make a warning go away.
+The initial budget is 1 MB warning / 1.2 MB error. It is meant to catch
+regressions, so keep it close to the actual size rather than raising it to make
+a warning go away - `pnpm build` prints the current initial total.
 
 ### Path Aliases
 
@@ -281,6 +281,24 @@ Only template-driven forms are in use:
   `:contrastId`) arrive as component `input()`s
 - Route guards live in `src/app/routes/` (`palette-route.guard.ts`,
   `contrast-route.guard.ts`)
+- A trailing `**` route renders `NotFound`
+  (`src/app/common/components/not-found/`). The SPA rewrite in
+  `public/_redirects` answers every path with `index.html` and HTTP 200, so an
+  unknown path cannot produce a real 404 status. The page makes the miss
+  visible to the visitor instead of leaving the viewport blank
+- Every route carries a `title`. Angular's `DefaultTitleStrategy` leaves the
+  previous title standing when a route has none, so a route without one shows
+  the tab title of wherever the visitor came from
+
+**An invalid id and an unknown path answer differently, on purpose.**
+`/palettes/garbage` matches `:paletteId`, so `paletteGuard` runs, finds the id
+unrestorable and redirects to a freshly generated palette - the visitor lands on
+a working tool. `/palettes/garbage/more` matches no route at all, falls through
+to `**` and gets the not-found page. The asymmetry is the intended reading of
+the two cases: an unrestorable id is recoverable input, because the route itself
+exists and the tool works without it; a path that names nothing is not. Do not
+"harmonize" the two by sending invalid ids to the not-found page - that would
+trade a working palette for a dead end. `app.routes.spec.ts` pins both halves.
 
 ### Services
 
@@ -313,14 +331,20 @@ Only template-driven forms are in use:
 
 ## Component Style Guidelines
 
-Components use inline SCSS styles configured in `angular.json`:
-
-- Schematics set `inlineStyle: true` by default. This stays the project
-  standard - do not migrate components to separate `.scss` files. The
-  `angular-development` skill asks for centralized topic files plus
-  component-specific overrides in the component's own style file; here that
-  override file *is* the inline `styles` block, so the two agree
-- Budget limits: 4kB warning, 8kB error per component (`anyComponentStyle`)
+- Schematics set `inlineStyle: true` by default, so a new component starts with
+  an inline `styles` block. Keep it there only for very short passages - a
+  handful of declarations that stay readable inside the decorator. Everything
+  beyond that belongs in the component's own `.scss` file next to it,
+  referenced through `styleUrl` (see `not-found.scss`, `color-area.scss`,
+  `color-picker.scss`)
+- The `angular-development` skill asks for centralized topic files plus
+  component-specific overrides in the component's own style file. That override
+  file is either the inline `styles` block or the sibling `.scss` - whichever
+  the length calls for; the split is about size, not about which mechanism is
+  the standard
+- Budget limits: 4kB warning, 8kB error per component (`anyComponentStyle`).
+  The budget counts either form, so moving a block out of the decorator does
+  not buy room
 - Global entry point is `src/styles.scss`
 - Cross-cutting styles live in `src/app/styles/` as topic-separated partials
   (`_variables.scss`, `_dark-mode.scss`, `_bootstrap-custom.scss`,
@@ -356,6 +380,3 @@ through `@use "./bootstrap-subset" with (...)` in `_bootstrap-custom.scss`.
   explicit environment setting and no `vitest.config.*` in the repo
 - Run all tests: `ng test` (or `pnpm test`); `ng test --watch=false` for a single run
 - Component generation skips test files by default (configured in angular.json schematics)
-- The suite currently consists of 149 tests in 5 helper specs (palette ID,
-  contrast ID, APCA rating, optimal text color, color name). No component or
-  store is tested

--- a/resources/404-Seite für Farbkonverter/404 Page.dc.html
+++ b/resources/404-Seite für Farbkonverter/404 Page.dc.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;600;700&family=DM+Sans:wght@400;500;700&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<style>
+  body { margin: 0; background: #ffffff; }
+  a { color: #d98800; text-decoration: none; }
+  a:hover { color: #b06f00; }
+  @keyframes drift { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+</style>
+</helmet>
+<div ref="{{ rootRef }}" style="min-height:100vh; display:flex; flex-direction:column; background:var(--bg,#ffffff); color:var(--fg,#1b1b19); font-family:'DM Sans',system-ui,sans-serif; -webkit-font-smoothing:antialiased">
+
+  <header style="display:flex; align-items:center; gap:32px; padding:14px 96px 14px 28px; background:var(--surface,#ffffff); border-bottom:1px solid var(--border,#e7e7e3); position:relative; z-index:2">
+    <a href="#" style="font-family:Archivo,sans-serif; font-size:28px; letter-spacing:-0.02em; color:var(--fg,#1b1b19)"><span style="color:var(--accent,#f0a202)">color</span><span style="font-weight:700">tools</span></a>
+    <nav style="display:flex; gap:24px; align-items:center; font-size:16px">
+      <a href="#" style="color:var(--fg,#1b1b19)">Converter</a>
+      <a href="#" style="color:var(--fg,#1b1b19)">Color Palette</a>
+      <a href="#" style="color:var(--fg,#1b1b19)">Contrast Checker</a>
+    </nav>
+    <div style="margin-left:auto; display:flex; align-items:center; gap:16px">
+      <button style="font-family:'DM Sans',sans-serif; font-size:15px; font-weight:500; padding:9px 18px; border-radius:999px; border:1px solid var(--accent,#f0a202); color:var(--accent,#f0a202); background:transparent; cursor:pointer" style-hover="background:rgba(240,162,2,0.10)" onClick="{{ randomize }}">New color</button>
+      <button onClick="{{ toggleTheme }}" title="Toggle theme" style="width:36px; height:36px; border-radius:999px; border:1px solid var(--border,#e7e7e3); background:transparent; color:var(--fg,#1b1b19); font-size:15px; cursor:pointer; display:flex; align-items:center; justify-content:center" style-hover="border-color:var(--accent,#f0a202)">{{ themeIcon }}</button>
+    </div>
+    <div style="position:absolute; top:0; right:0; width:60px; height:60px; background:var(--accent,#f0a202); clip-path:polygon(100% 0,0 0,100% 100%)"></div>
+  </header>
+
+  <main style="flex:1; display:flex; align-items:center; justify-content:center; padding:72px 28px 96px">
+    <div style="width:100%; max-width:960px; display:flex; flex-direction:column; gap:40px">
+
+      <div style="display:flex; flex-wrap:wrap; align-items:flex-end; gap:36px">
+        <div style="font-family:Archivo,sans-serif; font-weight:700; font-size:clamp(96px,17vw,200px); line-height:0.82; letter-spacing:-0.05em">4<span style="color:var(--accent,#f0a202)">0</span>4</div>
+        <div style="display:flex; flex-direction:column; gap:10px; padding-bottom:10px; flex:1 1 320px">
+          <div style="font-family:'DM Mono',ui-monospace,monospace; font-size:14px; letter-spacing:0.08em; text-transform:uppercase; color:var(--muted,#77776f)">Page not found</div>
+          <h1 style="margin:0; font-family:Archivo,sans-serif; font-weight:600; font-size:clamp(26px,3.4vw,38px); letter-spacing:-0.02em; line-height:1.15; text-wrap:pretty">This shade of the site doesn't exist.</h1>
+          <p style="margin:0; font-size:17px; line-height:1.55; color:var(--muted,#77776f); max-width:44ch; text-wrap:pretty">The link is broken or the page has moved. Pick up a tool below and keep going.</p>
+        </div>
+      </div>
+
+      <div>
+        <div style="display:flex; gap:10px; align-items:stretch; height:120px">
+          <sc-for list="{{ swatches }}" as="sw" hint-placeholder-count="8">
+            <div style="flex:1; display:flex; flex-direction:column; gap:8px; min-width:0">
+              <div style="flex:1; border-radius:14px; background:{{ sw.fill }}; border:{{ sw.stroke }}"></div>
+              <div style="font-family:'DM Mono',ui-monospace,monospace; font-size:12px; color:var(--muted,#77776f); white-space:nowrap; overflow:hidden; text-overflow:ellipsis">{{ sw.label }}</div>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+
+      <div style="display:flex; flex-wrap:wrap; gap:12px; align-items:center">
+        <a href="#" style="font-size:16px; font-weight:500; padding:14px 26px; border-radius:999px; background:var(--btn,#2f2c26); color:#ffffff" style-hover="background:var(--btn-hover,#45402f); color:#ffffff">Open the Converter</a>
+        <a href="#" style="font-size:16px; font-weight:500; padding:14px 26px; border-radius:999px; border:1px solid var(--border-strong,#cfcfc9); color:var(--fg,#1b1b19)" style-hover="border-color:var(--accent,#f0a202); color:var(--fg,#1b1b19)">Build a Color Palette</a>
+        <button onClick="{{ randomize }}" style="font-family:'DM Sans',sans-serif; font-size:16px; font-weight:500; padding:14px 26px; border-radius:999px; border:1px solid var(--accent,#f0a202); background:transparent; color:var(--accent,#f0a202); cursor:pointer" style-hover="background:rgba(240,162,2,0.10)">Random color</button>
+      </div>
+
+      <div style="display:flex; flex-wrap:wrap; gap:10px 22px; align-items:center; padding-top:8px; border-top:1px solid var(--border,#e7e7e3); font-size:15px; color:var(--muted,#77776f)">
+        <span>Requested address</span>
+        <span style="font-family:'DM Mono',ui-monospace,monospace; color:var(--fg,#1b1b19)">{{ path }}</span>
+      </div>
+
+    </div>
+  </main>
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;theme&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;light&quot;,&quot;dark&quot;],&quot;default&quot;:&quot;light&quot;,&quot;tsType&quot;:&quot;'light' | 'dark'&quot;},&quot;accentColor&quot;:{&quot;editor&quot;:&quot;color&quot;,&quot;default&quot;:&quot;#f0a202&quot;,&quot;options&quot;:[&quot;#f0a202&quot;,&quot;#ffb020&quot;,&quot;#f00e78&quot;,&quot;#2f2c26&quot;],&quot;tsType&quot;:&quot;string&quot;},&quot;requestedPath&quot;:{&quot;editor&quot;:&quot;text&quot;,&quot;default&quot;:&quot;/convert/burnt-sienna&quot;,&quot;tsType&quot;:&quot;string&quot;}}">
+const THEMES = {
+  light: {
+    '--bg': '#ffffff', '--surface': '#ffffff', '--fg': '#1b1b19', '--muted': '#77776f',
+    '--border': '#e7e7e3', '--border-strong': '#cfcfc9', '--btn': '#2f2c26', '--btn-hover': '#45402f',
+    '--accent': '#f0a202'
+  },
+  dark: {
+    '--bg': '#13151b', '--surface': '#13151b', '--fg': '#f3f3ef', '--muted': '#9a9aa2',
+    '--border': '#282c36', '--border-strong': '#3a3f4b', '--btn': '#2f2c26', '--btn-hover': '#45402f',
+    '--accent': '#ffb020'
+  }
+};
+
+class Component extends DCLogic {
+  state = { theme: null, hue: 28 };
+  rootRef = (el) => { this.rootEl = el; this.applyTheme(); };
+  componentDidMount() { this.applyTheme(); }
+  componentDidUpdate() { this.applyTheme(); }
+  get theme() { return this.state.theme || this.props.theme || 'light'; }
+  applyTheme() {
+    const el = this.rootEl;
+    if (!el) return;
+    const vars = THEMES[this.theme] || THEMES.light;
+    Object.entries(vars).forEach(([k, v]) => el.style.setProperty(k, v));
+    if (this.props.accentColor) el.style.setProperty('--accent', this.props.accentColor);
+  }
+  hex(h, s, l) {
+    const a = s * Math.min(l, 1 - l);
+    const f = n => {
+      const k = (n + h / 30) % 12;
+      const c = l - a * Math.max(-1, Math.min(k - 3, Math.min(9 - k, 1)));
+      return Math.round(255 * c).toString(16).padStart(2, '0');
+    };
+    return '#' + f(0) + f(8) + f(4);
+  }
+  renderVals() {
+    const dark = this.theme === 'dark';
+    const count = 8;
+    const solid = 5;
+    const swatches = [];
+    for (let i = 0; i < count; i++) {
+      if (i < solid) {
+        const l = dark ? 0.34 + i * 0.09 : 0.72 - i * 0.075;
+        const c = this.hex((this.state.hue + i * 9) % 360, 0.72, l);
+        swatches.push({ fill: c, stroke: '0px solid transparent', label: c.toUpperCase() });
+      } else {
+        swatches.push({
+          fill: 'transparent',
+          stroke: '1.5px dashed ' + (dark ? '#3a3f4b' : '#d8d8d2'),
+          label: '—'
+        });
+      }
+    }
+    return {
+      rootRef: this.rootRef,
+      swatches,
+      themeIcon: dark ? '☾' : '☀',
+      path: this.props.requestedPath ?? '/convert/burnt-sienna',
+      randomize: () => this.setState({ hue: Math.floor(Math.random() * 360) }),
+      toggleTheme: () => this.setState({ theme: dark ? 'light' : 'dark' })
+    };
+  }
+}
+
+</script>
+</body>
+</html>

--- a/src/app/app.routes.spec.ts
+++ b/src/app/app.routes.spec.ts
@@ -1,0 +1,213 @@
+import {TestBed} from "@angular/core/testing";
+import {provideRouter, Router} from "@angular/router";
+import {RouterTestingHarness} from "@angular/router/testing";
+import {provideZonelessChangeDetection} from "@angular/core";
+import {afterEach, beforeEach, describe, expect, it} from "vitest";
+import {routes} from "./app.routes";
+import {Converter} from "@converter/components/converter/converter";
+import {ColorPalette} from "@palettes/components/color-palette/color-palette";
+import {Contrast} from "@contrast/components/contrast/contrast";
+import {NotFound} from "@common/components/not-found/not-found";
+import {PALETTE_SLOTS} from "@palettes/models/palette.model";
+import chroma from "chroma-js";
+import {AppStateStore} from "@core/app-state.store";
+import {contrastIdFromColors} from "@contrast/helper/contrast-id.helper";
+
+
+describe("app routes", () => {
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter(routes)
+      ]
+    });
+  });
+
+
+  async function activatedComponentFor(path: string) {
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl(path);
+
+    let snapshot = router.routerState.snapshot.root;
+    while (snapshot.firstChild) snapshot = snapshot.firstChild;
+
+    return {component: snapshot.component, title: snapshot.title, url: router.url};
+  }
+
+
+  describe("the wildcard route", () => {
+
+    it("catches an unknown top level path", async () => {
+      const {component, url} = await activatedComponentFor("/does-not-exist");
+
+      expect(component).toBe(NotFound);
+      expect(url).toBe("/does-not-exist");
+    });
+
+
+    it("catches extra segments below a known route", async () => {
+      const {component} = await activatedComponentFor("/palettes/foo/bar");
+
+      expect(component).toBe(NotFound);
+    });
+
+
+    it("catches extra segments below the converter", async () => {
+      const {component} = await activatedComponentFor("/convert/extra");
+
+      expect(component).toBe(NotFound);
+    });
+
+
+    it("sets a page title", async () => {
+      const {title} = await activatedComponentFor("/does-not-exist");
+
+      expect(title).toBe("ColorTools – Page not found");
+    });
+
+  });
+
+
+  describe("the known routes", () => {
+
+    it("redirects the empty path to the converter", async () => {
+      const {component, url} = await activatedComponentFor("/");
+
+      expect(component).toBe(Converter);
+      expect(url).toBe("/convert");
+    });
+
+
+    it("still lets the palette guard generate an id", async () => {
+      const {component, url} = await activatedComponentFor("/palettes");
+
+      expect(component).toBe(ColorPalette);
+      expect(url).toMatch(/^\/palettes\/.+/);
+    });
+
+
+    it("still lets the contrast guard generate an id", async () => {
+      const {component, url} = await activatedComponentFor("/contrast");
+
+      expect(component).toBe(Contrast);
+      expect(url).toMatch(/^\/contrast\/.+/);
+    });
+
+
+    it("still lets the palette guard replace an invalid id", async () => {
+      const {component, url} = await activatedComponentFor("/palettes/garbage");
+
+      expect(component).toBe(ColorPalette);
+      expect(url).not.toBe("/palettes/garbage");
+    });
+
+
+    it("does not let the wildcard shadow a valid palette id", async () => {
+      const paletteId = TestBed.inject(AppStateStore).currentPalette().id;
+
+      const {component, url} = await activatedComponentFor(`/palettes/${paletteId}`);
+
+      expect(component).toBe(ColorPalette);
+      expect(url).toBe(`/palettes/${paletteId}`);
+    });
+
+
+    it("does not let the wildcard shadow a valid contrast id", async () => {
+      const contrastColors = TestBed.inject(AppStateStore).contrastColors();
+      const contrastId = contrastIdFromColors(contrastColors);
+
+      const {component, url} = await activatedComponentFor(`/contrast/${contrastId}`);
+
+      expect(component).toBe(Contrast);
+      expect(url).toBe(`/contrast/${contrastId}`);
+    });
+
+  });
+
+
+  describe("the not found page", () => {
+
+    afterEach(() => {
+      document.documentElement.style.removeProperty("--bs-primary");
+    });
+
+
+    it("names the path that was requested", async () => {
+      const harness = await RouterTestingHarness.create();
+      await harness.navigateByUrl("/does-not-exist");
+
+      expect(harness.routeNativeElement?.textContent).toContain("/does-not-exist");
+    });
+
+
+    it("renames the path when a second unknown path reuses the component", async () => {
+      const harness = await RouterTestingHarness.create();
+      await harness.navigateByUrl("/does-not-exist");
+      await harness.navigateByUrl("/also-does-not-exist");
+
+      expect(harness.routeNativeElement?.textContent).toContain("/also-does-not-exist");
+      expect(harness.routeNativeElement?.textContent).not.toContain("/does-not-exist");
+    });
+
+
+    it("links back to the three tools", async () => {
+      const harness = await RouterTestingHarness.create();
+      await harness.navigateByUrl("/does-not-exist");
+
+      const anchors = harness.routeNativeElement?.querySelectorAll("a") ?? [];
+      const hrefs = Array.from(anchors).map(anchor => anchor.getAttribute("href"));
+
+      expect(hrefs).toHaveLength(3);
+      expect(hrefs[0]).toBe("/convert");
+      expect(hrefs[1]).toMatch(/^\/palettes\/.+/);
+      expect(hrefs[2]).toMatch(/^\/contrast\/.+/);
+    });
+
+
+    async function swatchLabels(): Promise<string[]> {
+      const harness = await RouterTestingHarness.create();
+      await harness.navigateByUrl("/does-not-exist");
+
+      return Array.from(harness.routeNativeElement?.querySelectorAll(".swatch .label") ?? [])
+        .map(label => label.textContent?.trim() ?? "");
+    }
+
+
+    it("grows its swatches from the accent the theme declares", async () => {
+      // Deliberately not $primary - a hue the fallback cannot produce.
+      document.documentElement.style.setProperty("--bs-primary", "hsl(210, 80%, 40%)");
+
+      const filled = (await swatchLabels()).slice(0, PALETTE_SLOTS.length);
+
+      expect(filled.every(label => /^#[0-9A-F]{6}$/.test(label))).toBe(true);
+      expect(chroma(filled[0]).hsl()[0]).toBeCloseTo(210, 0);
+    });
+
+
+    it("falls back to $primary when the theme declares no accent", async () => {
+      // $primary in src/app/styles/_variables.scss.
+      const accentHue = 38.66;
+
+      const filled = (await swatchLabels()).slice(0, PALETTE_SLOTS.length);
+
+      expect(filled.every(label => /^#[0-9A-F]{6}$/.test(label))).toBe(true);
+      expect(chroma(filled[0]).hsl()[0]).toBeCloseTo(accentHue, 0);
+    });
+
+
+    it("leaves the swatches beyond the palette empty", async () => {
+      const harness = await RouterTestingHarness.create();
+      await harness.navigateByUrl("/does-not-exist");
+
+      const chips = harness.routeNativeElement?.querySelectorAll(".chip") ?? [];
+      const empty = harness.routeNativeElement?.querySelectorAll(".chip.empty") ?? [];
+
+      expect(chips).toHaveLength(8);
+      expect(empty).toHaveLength(8 - PALETTE_SLOTS.length);
+    });
+
+  });
+
+});

--- a/src/app/app.routes.spec.ts
+++ b/src/app/app.routes.spec.ts
@@ -10,6 +10,8 @@ import {Contrast} from "@contrast/components/contrast/contrast";
 import {NotFound} from "@common/components/not-found/not-found";
 import {PALETTE_SLOTS} from "@palettes/models/palette.model";
 import chroma from "chroma-js";
+import {injectDispatch} from "@ngrx/signals/events";
+import {converterEvents} from "@core/converter/converter.events";
 import {AppStateStore} from "@core/app-state.store";
 import {contrastIdFromColors} from "@contrast/helper/contrast-id.helper";
 
@@ -197,6 +199,21 @@ describe("app routes", () => {
     });
 
 
+    it("sends the top bar's New color button to the converter", async () => {
+      const router = TestBed.inject(Router);
+      // Instantiating the store registers allEffects(), navigateToConvert$
+      // among them.
+      TestBed.inject(AppStateStore);
+      const dispatch = TestBed.runInInjectionContext(() => injectDispatch(converterEvents));
+
+      await router.navigateByUrl("/does-not-exist");
+      dispatch.newRandomColorWithNav();
+      await waitForUrl(router, "/convert");
+
+      expect(router.url).toBe("/convert");
+    });
+
+
     it("leaves the swatches beyond the palette empty", async () => {
       const harness = await RouterTestingHarness.create();
       await harness.navigateByUrl("/does-not-exist");
@@ -211,3 +228,9 @@ describe("app routes", () => {
   });
 
 });
+
+async function waitForUrl(router: Router, url: string): Promise<void> {
+  for (let attempt = 0; attempt < 50 && router.url !== url; attempt++) {
+    await new Promise(resolve => setTimeout(resolve, 5));
+  }
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import {ColorPalette} from "@palettes/components/color-palette/color-palette";
 import {Contrast} from "@contrast/components/contrast/contrast";
 import {paletteGuard} from "./routes/palette-route.guard";
 import {contrastGuard} from "./routes/contrast-route.guard";
+import {NotFound} from "@common/components/not-found/not-found";
 
 
 export const routes: Routes = [
@@ -16,7 +17,8 @@ export const routes: Routes = [
   {
     path: "convert",
     component: Converter,
-    pathMatch: "full"
+    pathMatch: "full",
+    title: "ColorTools – Convert colors & Generate color palettes"
   },
 
   {
@@ -41,5 +43,11 @@ export const routes: Routes = [
         title: "ColorTools – Contrast Checker",
       }
     ]
+  },
+
+  {
+    path: "**",
+    component: NotFound,
+    title: "ColorTools – Page not found"
   }
 ];

--- a/src/app/common/components/not-found/not-found.html
+++ b/src/app/common/components/not-found/not-found.html
@@ -1,0 +1,54 @@
+<div class="not-found">
+
+  <div class="headline">
+    <p class="numeral" aria-hidden="true">4<span>0</span>4</p>
+
+    <div class="statement">
+      <p class="eyebrow">Page not found</p>
+      <h2>This shade of the site doesn’t exist.</h2>
+      <p class="intro">
+        The link is broken or the page has moved. Pick up a tool below and keep
+        going.
+      </p>
+    </div>
+  </div>
+
+  <div class="swatches" aria-hidden="true">
+    @for (swatch of swatches; track $index) {
+      <div class="swatch">
+        <div class="chip" [style.background-color]="swatch"></div>
+        <p class="label">{{ swatch }}</p>
+      </div>
+    }
+
+    @for (slot of missingSlots; track slot) {
+      <div class="swatch">
+        <div class="chip empty"></div>
+        <p class="label">—</p>
+      </div>
+    }
+  </div>
+
+  <nav class="actions" aria-label="ColorTools tools">
+    <a class="btn primary-action"
+       [routerLink]="['/convert']">
+      Open the Converter
+    </a>
+
+    <a class="btn"
+       [routerLink]="['/palettes', paletteId()]">
+      Build a Color Palette
+    </a>
+
+    <a class="btn"
+       [routerLink]="['/contrast', contrastId()]">
+      Check Contrast
+    </a>
+  </nav>
+
+  <p class="requested">
+    <span>Requested address</span>
+    <code>{{ requestedPath() }}</code>
+  </p>
+
+</div>

--- a/src/app/common/components/not-found/not-found.scss
+++ b/src/app/common/components/not-found/not-found.scss
@@ -1,0 +1,202 @@
+/* Archivo is the display face of the original design and is used for the
+   numeral alone. Loaded here rather than in `_bootstrap-custom.scss` so the
+   other three routes pay nothing for it, and subset via `text=404` to the two
+   digits it sets - anything else rendered in Archivo falls back to the body
+   font. */
+@import url("https://fonts.googleapis.com/css2?family=Archivo:wght@700&text=404&display=swap");
+
+:host {
+  display: flex;
+  align-items: center;
+
+  margin-inline: auto;
+  width: 100%;
+  max-width: 60rem;
+  min-height: calc(100dvh - var(--ct-header-height) - var(--ct-body-top-padding));
+  padding-inline: var(--ct-gutter-x);
+  padding-block: 2rem 4rem;
+
+  /* The requested path is arbitrary input - let it break instead of
+     pushing the page into a horizontal scroll. */
+  overflow-wrap: anywhere;
+}
+
+.not-found {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+
+  width: 100%;
+}
+
+.headline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 2.25rem;
+}
+
+.numeral {
+  margin: 0;
+
+  font-family: Archivo, var(--bs-font-sans-serif);
+  font-size: clamp(6rem, 17vw, 12.5rem);
+  font-weight: 700;
+  line-height: 0.82;
+  letter-spacing: -0.05em;
+
+  span {
+    color: var(--bs-primary);
+  }
+}
+
+.statement {
+  display: flex;
+  flex: 1 1 20rem;
+  flex-direction: column;
+  gap: 0.625rem;
+
+  padding-bottom: 0.625rem;
+
+  h2 {
+    margin: 0;
+
+    font-size: clamp(1.625rem, 3.4vw, 2.375rem);
+    letter-spacing: -0.02em;
+    line-height: 1.15;
+    text-wrap: pretty;
+  }
+}
+
+.eyebrow {
+  margin: 0;
+
+  font-family: var(--bs-font-monospace);
+  font-size: 0.875rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--bs-secondary-color);
+}
+
+.intro {
+  margin: 0;
+
+  max-width: 44ch;
+  font-size: 1.0625rem;
+  line-height: 1.55;
+  color: var(--bs-secondary-color);
+  text-wrap: pretty;
+}
+
+.swatches {
+  display: flex;
+  align-items: stretch;
+  gap: 0.625rem;
+
+  height: clamp(4.5rem, 14vw, 7.5rem);
+}
+
+.swatch {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  min-width: 0;
+}
+
+.chip {
+  flex: 1;
+  border-radius: var(--bs-border-radius);
+
+  /* A pastel slot can land close to the page background - an inset
+     hairline keeps the swatch an object rather than a hole. */
+  &:not(.empty) {
+    box-shadow: inset 0 0 0 1px var(--bs-border-color-translucent);
+  }
+
+  &.empty {
+    border: 1.5px dashed var(--bs-border-color-translucent);
+  }
+}
+
+.label {
+  margin: 0;
+
+  font-family: var(--bs-font-monospace);
+  font-size: 0.75rem;
+  color: var(--bs-secondary-color);
+
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* Bootstrap's .btn-secondary and .btn-outline-secondary resolve $secondary at
+   build time, so they stay dark brown in dark mode and drop below a readable
+   contrast. Driving the .btn base class through Bootstrap's own --bs-btn-*
+   variables keeps both buttons tied to the active theme. */
+.actions .btn {
+  --bs-btn-color: var(--bs-body-color);
+  --bs-btn-bg: transparent;
+  --bs-btn-border-color: var(--bs-secondary-color);
+  --bs-btn-hover-color: var(--bs-body-color);
+  --bs-btn-hover-bg: transparent;
+  --bs-btn-hover-border-color: var(--bs-primary);
+  --bs-btn-active-color: var(--bs-body-color);
+  --bs-btn-active-bg: transparent;
+  --bs-btn-active-border-color: var(--bs-primary);
+  --bs-btn-padding-x: 1.625rem;
+  --bs-btn-padding-y: 0.75rem;
+
+  /* Bootstrap defines --bs-btn-focus-shadow-rgb only in the .btn-* variant
+     mixins, never in the .btn base - without it .btn:focus-visible suppresses
+     the outline and paints no ring in its place. */
+  --bs-btn-focus-shadow-rgb: var(--bs-primary-rgb);
+}
+
+.actions .btn.primary-action {
+  --bs-btn-color: var(--bs-body-bg);
+  --bs-btn-bg: var(--bs-body-color);
+  --bs-btn-border-color: var(--bs-body-color);
+  /* Ink on the accent must not follow the theme - white on #fda300 is
+     2.02:1. --bs-dark clears AA against it in both themes. */
+  --bs-btn-hover-color: var(--bs-dark);
+  --bs-btn-hover-bg: var(--bs-primary);
+  --bs-btn-hover-border-color: var(--bs-primary);
+  --bs-btn-active-color: var(--bs-dark);
+  --bs-btn-active-bg: var(--bs-primary);
+  --bs-btn-active-border-color: var(--bs-primary);
+}
+
+.requested {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.625rem 1.375rem;
+
+  margin: 0;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--bs-border-color-translucent);
+
+  color: var(--bs-secondary-color);
+
+  code {
+    color: var(--bs-body-color);
+  }
+}
+
+/* Eight hex labels do not survive a phone-sized viewport - the swatches
+   still carry the colors, so drop the captions rather than truncate them. */
+@media (max-width: 575.98px) {
+  .label {
+    display: none;
+  }
+}

--- a/src/app/common/components/not-found/not-found.ts
+++ b/src/app/common/components/not-found/not-found.ts
@@ -1,0 +1,95 @@
+import {Component, computed, DOCUMENT, inject} from "@angular/core";
+import {ActivatedRoute, RouterLink} from "@angular/router";
+import {toSignal} from "@angular/core/rxjs-interop";
+import chroma, {Color} from "chroma-js";
+import {AppStateStore} from "@core/app-state.store";
+import {contrastIdFromColors} from "@contrast/helper/contrast-id.helper";
+import {PALETTE_SLOTS} from "@palettes/models/palette.model";
+import {paletteColorFrom} from "@palettes/models/palette-color.model";
+import {generatePalette} from "@palettes/helper/palette.helper";
+
+
+/** Filled slots plus the empty ones that stand in for the missing page. */
+const SWATCH_COUNT = 8;
+
+/**
+ * Mirrors `$primary` in `src/app/styles/_variables.scss` and is only reached
+ * when `--bs-primary` cannot be read - outside a browser, or before the
+ * stylesheet has landed.
+ */
+const ACCENT_FALLBACK = "hsl(38.66, 100%, 49.61%)";
+
+
+/**
+ * Renders the wildcard route.
+ *
+ * The SPA rewrite in `public/_redirects` answers every path with `index.html`
+ * and HTTP 200, so an unknown path cannot produce a real 404 status. This
+ * component makes the miss visible to the visitor instead of leaving the page
+ * blank, and links back to the three feature routes - keeping the palette and
+ * contrast colors the visitor already has, exactly as the top bar does.
+ */
+@Component({
+  selector: "ct-not-found",
+  imports: [RouterLink],
+  templateUrl: "./not-found.html",
+  styleUrl: "./not-found.scss"
+})
+export class NotFound {
+
+  readonly #document = inject(DOCUMENT);
+  readonly #route = inject(ActivatedRoute);
+  readonly #stateStore = inject(AppStateStore);
+
+  /**
+   * Two unknown paths share this route config, so the router reuses the
+   * component instance - a snapshot read would keep naming the first path.
+   */
+  readonly #segments = toSignal(this.#route.url, {initialValue: this.#route.snapshot.url});
+
+  protected readonly requestedPath = computed(
+    () => "/" + this.#segments().map(segment => segment.path).join("/")
+  );
+
+  /**
+   * A muted analogous palette grown from the accent color. Generated once per
+   * visit rather than read from the store, so the page keeps its designed look
+   * instead of inheriting whatever palette the visitor happens to carry.
+   */
+  protected readonly swatches = this.#accentPalette();
+
+  /**
+   * The empty slots trailing the palette. A ColorTools palette holds exactly
+   * `PALETTE_SLOTS.length` colors, so the remainder is what the page is
+   * missing - the visual echo of the route that does not exist.
+   */
+  protected readonly missingSlots = Array.from(
+    {length: SWATCH_COUNT - PALETTE_SLOTS.length},
+    (_, index) => index
+  );
+
+  protected readonly paletteId = computed(() => this.#stateStore.currentPalette().id);
+
+  protected readonly contrastId = computed(() => {
+    return contrastIdFromColors(this.#stateStore.contrastColors());
+  });
+
+
+  #accentPalette(): string[] {
+    const accent = paletteColorFrom(this.#accentColor(), "color0");
+    const palette = generatePalette("muted-analog-split", {color0: accent});
+
+    return PALETTE_SLOTS.map(slot => palette[slot].color.hex().toUpperCase());
+  }
+
+
+  /** Reads the accent straight off the theme so it cannot drift from `$primary`. */
+  #accentColor(): Color {
+    const declared = getComputedStyle(this.#document.documentElement)
+      .getPropertyValue("--bs-primary")
+      .trim();
+
+    return chroma(declared || ACCENT_FALLBACK);
+  }
+
+}

--- a/src/app/common/helpers/hsl.helper.spec.ts
+++ b/src/app/common/helpers/hsl.helper.spec.ts
@@ -1,0 +1,55 @@
+import {describe, expect, it} from "vitest";
+import {clamp01, clampHue, hueWrap} from "@common/helpers/hsl.helper";
+
+
+describe("clamp01", () => {
+
+  it("passes a fraction through untouched", () => {
+    expect(clamp01(0)).toBe(0);
+    expect(clamp01(0.5)).toBe(0.5);
+    expect(clamp01(0.99)).toBe(0.99);
+    expect(clamp01(1)).toBe(1);
+  });
+
+
+  it("caps an overshoot at 1", () => {
+    expect(clamp01(1.0005)).toBe(1);
+    expect(clamp01(1.05)).toBe(1);
+    expect(clamp01(42)).toBe(1);
+  });
+
+
+  it("caps an undershoot at 0", () => {
+    expect(clamp01(-0.01)).toBe(0);
+    expect(clamp01(-3)).toBe(0);
+  });
+
+});
+
+
+describe("clampHue", () => {
+
+  it("wraps a hue into [0, 360)", () => {
+    expect(clampHue(0)).toBe(0);
+    expect(clampHue(180)).toBe(180);
+    expect(clampHue(400)).toBe(40);
+    expect(clampHue(-30)).toBe(330);
+  });
+
+});
+
+
+describe("hueWrap", () => {
+
+  it("maps a full turn back to zero", () => {
+    expect(hueWrap(360)).toBe(0);
+    expect(hueWrap(720)).toBe(0);
+  });
+
+
+  it("leaves an in-range hue alone", () => {
+    expect(hueWrap(359)).toBe(359);
+    expect(hueWrap(38.66)).toBeCloseTo(38.66, 10);
+  });
+
+});

--- a/src/app/common/helpers/hsl.helper.ts
+++ b/src/app/common/helpers/hsl.helper.ts
@@ -27,13 +27,15 @@ export function hueWrap(h: number): number {
 /**
  * Clamps a given number to the range [0, 1].
  *
+ * Every caller passes a fraction that chroma-js produced or a generator
+ * offset it, so a value above 1 is an overshoot to be capped - not a
+ * percentage to be rescaled.
+ *
  * @param {number} x - The number to clamp.
  * @return {number} The clamped value, guaranteed to be between 0 and 1 (inclusive).
  */
 export function clamp01(x: number): number {
-  const max = x > 1 ? x / 100 : x;
-
-  return Math.max(0, Math.min(1, max));
+  return Math.max(0, Math.min(1, x));
 }
 
 export function inHslAngleRange(this: void, value: number | null): value is number {

--- a/src/app/common/models/new-click-source.model.spec.ts
+++ b/src/app/common/models/new-click-source.model.spec.ts
@@ -1,0 +1,25 @@
+import {describe, expect, it} from "vitest";
+import {routePathToSource} from "@common/models/new-click-source.model";
+
+
+describe("routePathToSource", () => {
+
+  it("recognises the feature routes", () => {
+    expect(routePathToSource("/convert")).toBe("convert");
+    expect(routePathToSource("/palettes/0EEyV2")).toBe("palettes");
+    expect(routePathToSource("/contrast/1HvWWobCq")).toBe("contrast");
+  });
+
+
+  it("falls back to the converter for an unknown path", () => {
+    expect(routePathToSource("/does-not-exist")).toBe("convert");
+    expect(routePathToSource("/does-not-exist/deeper")).toBe("convert");
+  });
+
+
+  it("falls back to the converter for the root and for junk", () => {
+    expect(routePathToSource("/")).toBe("convert");
+    expect(routePathToSource("")).toBe("convert");
+  });
+
+});

--- a/src/app/common/models/new-click-source.model.ts
+++ b/src/app/common/models/new-click-source.model.ts
@@ -1,9 +1,22 @@
 export type NewClickSource = "palettes" | "convert" | "contrast";
 
+
+/**
+ * Maps a route path to the tool whose "New" action the top bar should trigger.
+ *
+ * Anything that is not a feature route - the wildcard route above all - falls
+ * back to the converter. The button then does what its caption says instead of
+ * matching no case at all, which is what an unchecked cast to `NewClickSource`
+ * used to produce.
+ */
 export function routePathToSource(routePath: string): NewClickSource {
-  const splitRoute = routePath.split("/");
+  const segment = routePath.split("/")[1];
 
-  if (splitRoute.length < 2) return "convert";
-
-  return splitRoute[1] as NewClickSource;
+  switch (segment) {
+    case "palettes":
+    case "contrast":
+      return segment;
+    default:
+      return "convert";
+  }
 }

--- a/src/app/core/all-effects.ts
+++ b/src/app/core/all-effects.ts
@@ -12,7 +12,7 @@ import {colorThemeChangeEffect, fontSelectedEffect} from "@core/common/common.ef
 import {colorChangedEffect, useAsBackgroundChangedEffect} from "@core/converter/converter.effects";
 import {map} from "rxjs";
 import {saveStateEffect} from "@core/common/persistence.effects";
-import {navigateToContrast, navigateToPaletteIdEffect} from "@core/common/navigation.effects";
+import {navigateToContrast, navigateToConvert, navigateToPaletteIdEffect} from "@core/common/navigation.effects";
 import {contrastEvents} from "@core/contrast/contrast.events";
 import {transferEvents} from "@core/common/transfer.events";
 
@@ -39,13 +39,15 @@ export function allEffects(
 
     navigateToContrast$: navigateToContrast(events, router, store),
 
+    navigateToConvert$: navigateToConvert(events, router),
+
     colorChanged$: colorChangedEffect(events, themeService, store),
 
     anyPersistableEvents$: events
       .on(
         commonEvents.colorThemeChanged,
         commonEvents.fontSelected,
-        converterEvents.newRandomColor,
+        converterEvents.newRandomColorWithNav,
         converterEvents.colorChanged,
         palettesEvents.paletteChanged,
         palettesEvents.paletteChangedWithoutNav,

--- a/src/app/core/app-state.store.ts
+++ b/src/app/core/app-state.store.ts
@@ -43,7 +43,7 @@ export const AppStateStore = signalStore(
     on(transferEvents.useColorAsPaletteStarter, useColorAsPaletteStarterReducer),
     on(transferEvents.sendColorToContrast, sendColorToContrastReducer),
     on(transferEvents.generatePaletteFromContrast, generatePaletteFromContrastReducer),
-    on(converterEvents.newRandomColor, newRandomColorReducer),
+    on(converterEvents.newRandomColorWithNav, newRandomColorReducer),
     on(converterEvents.colorChanged, colorChangedReducer),
     on(converterEvents.useAsBackgroundChanged, useAsBackgroundReducer),
     on(converterEvents.correctLightnessChanged, correctLightnessReducer),

--- a/src/app/core/common/navigation.effects.ts
+++ b/src/app/core/common/navigation.effects.ts
@@ -6,6 +6,7 @@ import {tap} from "rxjs";
 import {transferEvents} from "@core/common/transfer.events";
 import {contrastIdFromColors} from "@contrast/helper/contrast-id.helper";
 import {contrastEvents} from "@core/contrast/contrast.events";
+import {converterEvents} from "@core/converter/converter.events";
 
 
 export function navigateToPaletteIdEffect(
@@ -54,6 +55,27 @@ export function navigateToContrast(
       tap(() => {
         const contrastId = contrastIdFromColors(typedStore.contrastColors());
         void router.navigate(["/contrast", contrastId]);
+      })
+    );
+}
+
+
+/**
+ * The converter lives at a fixed path, so unlike the palette and contrast
+ * effects this one needs no id from the store. Navigating while already on
+ * /convert is a no-op; the effect exists for the top bar's "New color" button
+ * on every other route, the not-found page above all.
+ */
+export function navigateToConvert(
+  this: void,
+  events: Events,
+  router: Router
+) {
+  return events
+    .on(converterEvents.newRandomColorWithNav)
+    .pipe(
+      tap(() => {
+        void router.navigate(["/convert"]);
       })
     );
 }

--- a/src/app/core/converter/converter.effects.ts
+++ b/src/app/core/converter/converter.effects.ts
@@ -14,7 +14,7 @@ export function colorChangedEffect(
   const typedStore = store as AppStateStore;
 
   return events
-    .on(converterEvents.colorChanged, converterEvents.newRandomColor)
+    .on(converterEvents.colorChanged, converterEvents.newRandomColorWithNav)
     .pipe(
       tap(() => {
         const color = typedStore.currentColor();

--- a/src/app/core/converter/converter.events.ts
+++ b/src/app/core/converter/converter.events.ts
@@ -7,7 +7,7 @@ import {ColorSpace} from "@common/models/color-space.model";
 export const converterEvents = eventGroup({
   source: "Converter",
   events: {
-    newRandomColor: type<void>(),
+    newRandomColorWithNav: type<void>(),
     colorChanged: type<Color>(),
     useAsBackgroundChanged: type<boolean>(),
     correctLightnessChanged: type<boolean>(),

--- a/src/app/core/converter/converter.reducers.ts
+++ b/src/app/core/converter/converter.reducers.ts
@@ -8,7 +8,7 @@ import {contrastingColor} from "@common/helpers/contrasting-color.helper";
 
 export function newRandomColorReducer(
   this: void,
-  event: EventInstance<"[Converter] newRandomColor", void>,
+  event: EventInstance<"[Converter] newRandomColorWithNav", void>,
   state: AppState
 ) {
   const currentColor = chroma.random();

--- a/src/app/header/components/top-bar/top-bar.ts
+++ b/src/app/header/components/top-bar/top-bar.ts
@@ -80,7 +80,7 @@ export class TopBar implements OnInit, OnDestroy {
         this.#palettesDispatch.newPaletteWithNav();
         return;
       case "convert":
-        this.#converterDispatch.newRandomColor();
+        this.#converterDispatch.newRandomColorWithNav();
         return;
       case "contrast":
         this.#contrastDispatch.newRandomColorsWithNav();


### PR DESCRIPTION
Closes #49.

Six commits: a bug in the shared color math, then the page, then the top-bar button the page made visible, then the documentation and tooling that follow from them.

| Commit | |
|---|---|
| Fix `clamp01` turning an overshoot into near-zero | found while building the page, but app-wide |
| Answer unknown paths with a not-found page | the issue |
| Make the top bar's New button work off-route | pre-existing, but first noticeable here |
| Correct `CLAUDE.md` on routing and styles | the decisions below, written down |
| Bump the `.claude` submodule to 3fda382 | unrelated to the issue; it was simply due |
| Adopt the no-hard-wrap rule for GitHub text | follows from the bump; this description is the first text under it |

## The route

`app.routes.ts` had no `**` route, so any path missing the three feature routes rendered nothing. The Cloudflare move made that visible rather than worse — the SPA rewrite answers every path with `index.html` and HTTP 200, where `angular-cli-ghpages` had served a `404.html` that was a copy of `index.html` and loaded the same routeless app.

Three decisions, all taken deliberately:

- **A dedicated component, not a redirect to `/convert`.** The page names the requested path instead of silently pretending the visitor asked for something else.
- **No real 404 status.** It needs either an enumerated path list in `_redirects` or SSR, and neither earns its keep for three routes with a `sitemap.xml`. `public/_redirects` is unchanged.
- **The guards keep their behaviour.** An invalid or missing palette/contrast ID still generates a new one and redirects; only paths matching no route at all reach the wildcard. The issue asked for the two cases to behave consistently, and this is the answer rather than an omission: an unrestorable ID is recoverable input, because the route exists and the tool works without it, while a path that names nothing is not. `CLAUDE.md` now carries that reasoning, so the asymmetry is not mistaken for an oversight later.

Route matching turned out subtler than it looks, so I checked it against the real router rather than reasoning about it. A componentless parent with only a `:param` child **does** match its own bare path — so `/palettes` still reaches its guard and gets an ID, while `/palettes/foo/bar` and `/convert/extra` fall through to the wildcard. `app.routes.spec.ts` pins all of it, including that the wildcard shadows no valid ID.

The `convert` route gains the `title` it never had. Without one the router's `DefaultTitleStrategy` leaves the previous title standing, so the new "Page not found" survived a click on this page's own Converter link. The string matches `index.html`, so the first-load title is unchanged. Outside the issue's scope, but introduced by it.

## The `clamp01` bug

`clamp01` divided by 100 whenever its input exceeded 1, assuming a percentage. Every caller passes a fraction from chroma-js, so the branch only ever met overshoots: `clamp01(1.0005)` returned `0.010005`, and a color one thousandth too light came out all but black.

The palette generators sit on that edge by construction — each computes a channel, then jitters it with `vary()`. The muted-analog-split pastel is `l0 + 0.48`, which for an accent at lightness 0.4961 lands on 0.976 with a ±0.05 jitter.

| | collapsed to near-black |
|---|---|
| before | **542 / 2000** generated palettes |
| after | **0 / 2000** |

Tints, shades and the other nine styles are exposed the same way wherever an offset approaches 1. `hsl.helper.ts` had no spec; it has one now, and the overshoot case is the regression it exists for.

## The inert New button

`routePathToSource()` read the first path segment and cast it to `NewClickSource` unchecked. Off the three feature routes the top bar therefore held a value matching no `case` in `triggerNew()`, so the button showed its fall-through caption and did nothing. Pre-existing — the top bar always rendered on unknown paths — but the not-found page is the first such page worth looking at, so the dead button stopped being theoretical.

The cast is gone: the two ids that mean something are matched explicitly and everything else falls back to the converter. Since the converter is not where the visitor is standing, the action has to navigate, so `newRandomColor` becomes `newRandomColorWithNav` — the naming the other two domains already use — and gains a `navigateToConvert$` effect beside `navigateToPalette$` and `navigateToContrast$`. It needs nothing from the store; the converter sits at a fixed path. Navigating while already on `/convert` is a no-op, and the top bar was the event's only dispatcher, so nothing else changes.

## The design

A port of a Claude Design draft, kept in `resources/` beside the other design sources. What changed on the way in:

| Draft | Here |
|---|---|
| Archivo, DM Sans, DM Mono | the project's Inter and Cousine — Archivo survives for the numeral alone |
| hard-coded hex values | `--bs-*` variables; the draft's accent `#f0a202` was already `$primary` |
| mocked header/nav | dropped — the app renders its own top bar |
| hard-coded swatches | a muted-analogous palette grown from the accent |
| "Random color" button | the third tool link, so all three are reachable |

Archivo is imported from the component's own stylesheet rather than `_bootstrap-custom.scss`, and subset via `text=404` to the two digits it sets. Measured against the built artifact: the 404 page makes **4** font requests, the converter **3**. Angular resolves the `@import` at build time into a `@font-face` on `fonts.gstatic.com`, so the `fonts.googleapis.com` round trip disappears in production.

Five filled swatches is exactly `PALETTE_SLOTS`; the three empty ones are what the palette is missing, which is the same gap as the route.

## Accessibility

Two WCAG failures caught in review, both from using bare Bootstrap classes:

- **1.4.3** — the filled button hovered white on `#fda300`: **2.02:1**. Now `--bs-dark`, **7.65:1** in both themes.
- **2.4.7** — no focus ring. Bootstrap defines `--bs-btn-focus-shadow-rgb` only in the `.btn-*` variant mixins, never in the `.btn` base, so the `box-shadow` was invalid and the suppressed `outline: 0` had no replacement.

The buttons drive `.btn` through Bootstrap's `--bs-btn-*` variables instead of using `.btn-secondary`. The variant classes resolve `$secondary` at build time and `_bootstrap-custom.scss` never passes `$secondary-dark` through, so they stay dark brown in dark mode — 2.16:1 on the dark background.

## Documentation

Reviewing the branch turned up three claims in `CLAUDE.md` that the codebase did not support. Each is corrected in the fourth commit:

| Claim | Reality |
|---|---|
| three feature routes and their guards, no wildcard | the `**` route is documented, along with why no real 404 status is reachable and why the guards differ from it |
| "do not migrate components to separate `.scss` files" | `color-area` and `color-picker` have used `styleUrl` all along, and `not-found.scss` joins them. The rule is now about length: short passages stay inline, anything longer moves next to the component |
| a test count and a bundle size in prose | both gone. They meant editing this file for every test added and every kilobyte shifted; the budget paragraph points at `pnpm build` instead |

The submodule bump is unrelated to the issue and rides along only because it was due. It picks up [skills#27](https://github.com/raywo-personal/claude-agents-and-skills/pull/27), a semantic-line-break rule for GitHub text, which the submodule README asks each project to adopt in its own `CLAUDE.md`. Adopted in the sixth commit, so this description is the first one written under it: one line per paragraph, list item and table row, with the wording unchanged from the wrapped version.

## Verification

- **175/175 tests pass** (was 149). `app.routes.spec.ts` is this repo's first routing-level spec. The navigation test is mutation-verified: dropping `navigateToConvert$` from `allEffects()` fails it.
- Rendered and clicked through in Chrome at 1280px and 390px, light and dark, against both the dev server and the production build. All four routes checked for the New button: `/convert` keeps its URL and rerolls, `/palettes` and `/contrast` still generate and redirect, the not-found page moves to `/convert` with a fresh color.
- No lint tooling is configured; TypeScript strict checking runs in the build and is clean.

| | before | after |
|---|---|---|
| initial total | 935.99 kB | **942.88 kB** |

Budget is 1 MB warning / 1.2 MB error.

## Known trade-offs

- `requestedPath` drops the query string and fragment — `/foo?x=1` shows as `/foo`.
- The outline buttons' hover border is `--bs-primary` at 2.02:1 in light mode. Hover is supplementary and focus is covered by the ring, so it stands.
- Only the `.dc.html` of the design export is tracked. The archive, the canvas runtime and the screenshots are regenerated on every export and would have added 2.2 MB — so the tracked file is a design source, not a runnable page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

