### PR TITLE
Drop the .claude submodule for the rw plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".claude"]
-	path = .claude
-	url = git@github.com:raywo-personal/claude-agents-and-skills.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,37 +40,19 @@ The project has four build configurations:
 - `development` - Dev build with source maps, no optimization
 - `testing` - Build target consumed by the `test` target; not meant to be built directly
 
-## Git and the `.claude` Submodule
+## Claude Code Agents And Skills
 
-`.claude` is a git submodule pointing at
-`raywo-personal/claude-agents-and-skills`. That repository is **shared across
-projects**, so a change to a skill affects every project embedding it.
+The skills and agents this project relies on come from the `rw` plugin
+(marketplace `raywo-personal`, repository
+`raywo-personal/claude-agents-and-skills`). The plugin is installed per user,
+not vendored into this repository - there is nothing under `.claude/` to
+commit, and `.claude/settings.local.json` stays untracked.
 
-This has two consequences worth knowing before touching anything under
-`.claude/`:
-
-**Project-specific rules do not belong there.** If a convention only holds for
-ColorTools, it goes in this file. The skills describe general practice; this
-file describes what this codebase actually does, and it wins where the two
-differ.
-
-**Committing a skill change takes two repositories.** The parent records a
-commit hash, not a branch, so the order matters:
-
-1. In `.claude`: branch off `main`, commit, push, open a PR
-2. After the PR is merged: `git -C .claude switch main` and
-   `git -C .claude merge --ff-only origin/main`
-3. Only then stage `.claude` in the parent and commit the pointer bump
-
-Do not bump the pointer to a commit that exists only on a feature branch — a
-fresh clone running `git submodule update` would not be able to check it out.
-Until step 3, `git status` showing `M .claude` is the correct intermediate
-state, not something to fix.
-
-**Check for drift before starting.** The submodule can sit far behind its
-remote while its working tree looks current, because files copied in by hand
-are untracked. `git -C .claude fetch` and compare with
-`git -C .claude rev-list --left-right --count origin/main...HEAD` first.
+That plugin is **shared across projects**, so a change to a skill affects every
+project using it. Project-specific rules therefore do not belong there: if a
+convention only holds for ColorTools, it goes in this file. The skills describe
+general practice; this file describes what this codebase actually does, and it
+wins where the two differ.
 
 ## Writing Text For GitHub
 
@@ -86,8 +68,8 @@ Hard-wrapping stays for anything read in monospace without reflow: commit
 messages (subject at most 50 characters, body wrapped at 72), files in this
 repository including this one, and code comments.
 
-This is the convention from the `.claude` submodule's README, adopted here
-because that README asks each project to adopt it explicitly - the rule applies
+This is the convention from the `rw` plugin's README, adopted here because
+that README asks each project to adopt it explicitly - the rule applies
 whenever GitHub text is written, including when no skill is running.
 
 ## Architecture
@@ -245,7 +227,7 @@ Always use these aliases for imports within the codebase.
 ## Angular and TypeScript Conventions
 
 These are the binding conventions for this repository. The
-`angular-development` skill in `.claude/skills/` carries the general Angular
+`angular-development` skill from the `rw` plugin carries the general Angular
 guidance; where the two differ, this file wins because it describes what this
 codebase actually does.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Try it out here: https://color-tools.skillbird.de/
 
 1. Clone the repository:
    ```bash
-   git clone --recurse-submodules https://github.com/raywo-personal/color-tools.git
+   git clone https://github.com/raywo-personal/color-tools.git
    ```
 
 2. Install dependencies:
@@ -51,24 +51,11 @@ Try it out here: https://color-tools.skillbird.de/
    pnpm build
    ```
    
-### Update Claude Code agents and skills
+### Claude Code agents and skills
 
-1. Update the submodule:
-   ```bash
-   cd .claude
-   git fetch           # get new commits from remote
-   git checkout main   # or your default branch
-   git pull            # get latest changes
-   ```
-
-2. Update the project
-   ```Bash
-   cd ..
-   git status          # shows: .claude has uncommitted changes
-   git add .claude
-   git commit -m "Update Claude knowledge submodule"
-   git push
-   ```
+Agents and skills come from the `rw` plugin (marketplace `raywo-personal`).
+Install it once per machine with `/plugin`; nothing about it is stored in this
+repository.
 
 ### Deployment
 


### PR DESCRIPTION
Skills and agents now come from the `rw` plugin (marketplace `raywo-personal`), installed per user from the same repository the submodule pointed at. Vendoring them a second time only bought the two-repository commit dance that the removed CLAUDE.md section had to describe.

## Changes

- Removed the `.claude` submodule from the index, `.gitmodules`, the worktree and the leftover `.git/config` and `.git/modules` entries
- `CLAUDE.md`: replaced the "Git and the `.claude` Submodule" section with "Claude Code Agents And Skills", which names the plugin as the source and keeps the rule that project-specific conventions belong in `CLAUDE.md`, not in a shared skill. The references to the submodule README and to `.claude/skills/` now point at the plugin
- `README.md`: dropped `--recurse-submodules` from the clone command and replaced the submodule-update instructions with a short note on installing the plugin

`.claude/` remains as an untracked directory holding `settings.local.json`, which was already gitignored.

## Note

The plugin carries every skill the submodule had, plus `training-design` and `word-document-styles`. It does **not** carry the two agents that lived in the submodule: `angular-app-creator` and `openapi-documentation-creator`. Those are gone with this change. If they are still wanted, they belong in the plugin repository under `agents/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)